### PR TITLE
Add context to share data between steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Add context to share data between different steps
+- Expose the context through environmental variables for the scripts
+- Add documentation for the environmental variables
+
 ## [0.2.2] - 2024-02-17
 
 - Add `-v` flag to increase verbosity, default log level changed to INFO

--- a/docs/content/guides/development.md
+++ b/docs/content/guides/development.md
@@ -18,5 +18,5 @@ gw /path/to/repo -s 'npm run build' -s 'npx pm2 restart'
 You can use the `notify-send` command to popup notifications on Linux, let's use it to show if somebody commited to our branch.
 
 ```sh
-gw /path/to/repo -s 'notify-send "$GW_COMMIT_AUTHOR has commited to your branch"'
+gw /path/to/repo -s 'notify-send "There are new commits on your branch!"'
 ```

--- a/docs/content/guides/netlify.md
+++ b/docs/content/guides/netlify.md
@@ -13,12 +13,12 @@ If you want to generate a version for every commit of your code, and expose it a
 
 The main idea behind this solution is that most static site generators allow changing output directories. We can wire this together with the git short hash set in the environment by `gw`, and build the different versions side-by-side.
 
-For this you have to find the output directory flag in your static site generator and set it to the `GW_COMMIT_SHORTHASH` variable. For example for Jekyll and Hugo this is the `--destination` flag, in 11ty this is the `--output` flag.
+For this you have to find the output directory flag in your static site generator and set it to the `GW_GIT_COMMIT_SHORT_SHA` variable. For example for Jekyll and Hugo this is the `--destination` flag, in 11ty this is the `--output` flag.
 
 ```sh
-jekyll build --destination=output/$GW_COMMIT_SHORTHASH
-hugo --destination=output/$GW_COMMIT_SHORTHASH
-npx @11ty/eleventy --input=. --output=output/$GW_COMMIT_SHORTHASH
+jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA
+hugo --destination=output/$GW_GIT_COMMIT_SHORT_SHA
+npx @11ty/eleventy --input=. --output=output/$GW_GIT_COMMIT_SHORT_SHA
 ```
 
 ## gw configuration
@@ -26,7 +26,7 @@ npx @11ty/eleventy --input=. --output=output/$GW_COMMIT_SHORTHASH
 You can use this command to configure your `gw`:
 
 ```sh
-gw /path/to/directory --script 'jekyll build --destination=output/$GW_COMMIT_SHORTHASH'
+gw /path/to/directory --script 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA'
 ```
 
 ## Web server configuration

--- a/docs/content/reference/environment-variables.md
+++ b/docs/content/reference/environment-variables.md
@@ -5,3 +5,45 @@ weight = 1
 
 # Environment variables
 
+The different steps can add variables to the context, which are exposed to the scripts as environment variables.
+All of these are prefixed with `GW_` to avoid collisions. The second part usually identifies the specific trigger,
+check or action.
+
+A good way to debug environment variables is to print the variables with `--script "printenv"`.
+
+## Trigger variables
+
+These are the variables that are exposed from the trigger, which can be scheduled trigger or an HTTP endpoint.
+
+| Variable name       | Example            | Notes                                   |
+| ------------------- | ------------------ | --------------------------------------- |
+| `GW_TRIGGER_NAME`   | `SCHEDULE`, `HTTP` | The identifier of the trigger.          |
+| `GW_HTTP_METHOD`    | `GET`, `POST`      | The HTTP method that was called.        |
+| `GW_HTTP_URL`       | `/`, `/trigger`    | The HTTP URL that was called.           |
+| `GW_SCHEDULE_DELAY` | `1m`, `1d`, `1w`   | The delay between two scheduled checks. |
+
+## Check variables
+
+These are the variables that are exposed from the check, which currently is always git.
+
+| Variable name                    | Example                              | Notes                                        |
+| -------------------------------- | ------------------------------------ | -------------------------------------------- |
+| `GW_CHECK_NAME`                  | `GIT`                                | The identifier of the check.                 |
+| `GW_GIT_BEFORE_COMMIT_SHA`       | `acfd4f88da199...`                   | The SHA of the commit before the pull.       |
+| `GW_GIT_BEFORE_COMMIT_SHORT_SHA` | `acfd4f8`                            | The 7-character short hash of the commit.    |
+| `GW_GIT_BRANCH_NAME`             | `main`                               | The name of the branch, that the repo is on. |
+| `GW_GIT_COMMIT_SHA`              | `acfd4f88da199...`                   | The SHA of the commit after the pull.        |
+| `GW_GIT_COMMIT_SHORT_SHA`        | `acfd4f8`                            | The 7-character short hash of the commit.    |
+| `GW_GIT_REF_NAME`                | `refs/heads/main`, `refs/tags/v1.0`  | The full name of the current git ref.        |
+| `GW_GIT_REF_TYPE`                | `branch`, `tag`                      | The type of the ref we are currently on.     |
+| `GW_GIT_REMOTE_NAME`             | `origin`                             | The name of the remote used.                 |
+| `GW_GIT_REMOTE_URL`              | `git@github.com:daniel7grant/gw.git` | The URL to the git remote.                   |
+
+## Action variables
+
+These are the variables added by the action, which currently is always script.
+
+| Variable name    | Example        | Notes                                       |
+| ---------------- | -------------- | ------------------------------------------- |
+| `GW_ACTION_NAME` | `SCRIPT`       | The identifier of the action.               |
+| `GW_DIRECTORY`   | `/src/http/gw` | The absolute path to the current directory. |

--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -40,3 +40,24 @@ a:not([href^='#']):hover {
         display: none;
     }
 }
+
+table {
+    text-align: left;
+}
+
+table td:nth-child(1),
+table td:nth-child(2) {
+    max-width: 120px;
+}
+
+
+@media screen and (min-width: 800px) {
+    table td:nth-child(1),
+    table td:nth-child(2) {
+        max-width: 200px;
+    }
+}
+
+table code {
+    word-wrap: break-word;
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use crate::context::Context;
 use mockall::automock;
 use thiserror::Error;
 
@@ -28,5 +27,5 @@ pub enum ActionError {
 #[automock]
 pub trait Action {
     /// Initiate the action
-    fn run(&self, context: &HashMap<String, String>) -> Result<(), ActionError>;
+    fn run(&self, context: &Context) -> Result<(), ActionError>;
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use mockall::automock;
 use thiserror::Error;
 
@@ -26,5 +28,5 @@ pub enum ActionError {
 #[automock]
 pub trait Action {
     /// Initiate the action
-    fn run(&self) -> Result<(), ActionError>;
+    fn run(&self, context: &HashMap<String, String>) -> Result<(), ActionError>;
 }

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -1,10 +1,12 @@
-use self::repository::GitRepository;
+use self::repository::{shorthash, GitRepository, GitRepositoryInformation};
 use super::{Check, CheckError};
 use std::{collections::HashMap, fmt::Debug};
 use thiserror::Error;
 
 mod credentials;
 mod repository;
+
+const CHECK_NAME: &str = "GIT";
 
 /// A check to fetch and pull a local git repository.
 ///
@@ -18,6 +20,9 @@ pub enum GitError {
     /// The directory is not a valid git repository.
     #[error("{0} does not exist or not a git repository")]
     NotAGitRepository(String),
+    /// Cannot parse HEAD, either stuck an unborn branch or some deleted reference
+    #[error("HEAD is invalid, probably points to invalid commit")]
+    NoHead,
     /// There is no branch in the repository currently. It can be a repository
     /// without any branch, or checked out on a commit.
     #[error("repository is not on a branch")]
@@ -48,6 +53,7 @@ impl From<GitError> for CheckError {
     fn from(value: GitError) -> Self {
         match value {
             GitError::NotAGitRepository(_)
+            | GitError::NoHead
             | GitError::NotOnABranch
             | GitError::NoRemoteForBranch(_) => CheckError::Misconfigured(value.to_string()),
             GitError::ConfigLoadingFailed => CheckError::PermissionDenied(value.to_string()),
@@ -68,10 +74,53 @@ impl GitCheck {
         Ok(GitCheck(repo))
     }
 
-    fn check_inner(&mut self, _context: &mut HashMap<String, String>) -> Result<bool, GitError> {
+    fn check_inner(&mut self, context: &mut HashMap<String, String>) -> Result<bool, GitError> {
         let GitCheck(repo) = self;
+
+        // Load context data from repository information
+        let information = repo.get_repository_information()?;
+        context.insert("CHECK_NAME".to_string(), CHECK_NAME.to_string());
+        match information {
+            GitRepositoryInformation::Branch {
+                ref_type,
+                ref_name,
+                branch_name,
+                commit_sha,
+                commit_short_sha,
+                remote_name,
+                remote_url,
+            } => {
+                context.insert("GIT_REF_TYPE".to_string(), ref_type);
+                context.insert("GIT_REF_NAME".to_string(), ref_name);
+                context.insert("GIT_BRANCH_NAME".to_string(), branch_name);
+                context.insert("GIT_BEFORE_COMMIT_SHA".to_string(), commit_sha.clone());
+                context.insert("GIT_BEFORE_COMMIT_SHORT_SHA".to_string(), commit_short_sha.clone());
+                context.insert("GIT_COMMIT_SHA".to_string(), commit_sha);
+                context.insert("GIT_COMMIT_SHORT_SHA".to_string(), commit_short_sha);
+                context.insert("GIT_REMOTE_NAME".to_string(), remote_name);
+                context.insert("GIT_REMOTE_URL".to_string(), remote_url);
+            }
+            GitRepositoryInformation::Reference {
+                ref_type,
+                ref_name,
+                commit_sha,
+                commit_short_sha,
+            } => {
+                context.insert("GIT_REF_TYPE".to_string(), ref_type);
+                context.insert("GIT_REF_NAME".to_string(), ref_name);
+                context.insert("GIT_BEFORE_COMMIT_SHA".to_string(), commit_sha);
+                context.insert("GIT_BEFORE_COMMIT_SHORT_SHA".to_string(), commit_short_sha);
+            }
+        }
+
+        // Pull repository contents and report
         let fetch_commit = repo.fetch()?;
         if repo.check_if_updatable(&fetch_commit)? && repo.pull(&fetch_commit)? {
+            context.insert("GIT_COMMIT_SHA".to_string(), fetch_commit.id().to_string());
+            context.insert(
+                "GIT_COMMIT_SHORT_SHA".to_string(),
+                shorthash(&fetch_commit.id().to_string()),
+            );
             Ok(true)
         } else {
             Ok(false)
@@ -140,6 +189,12 @@ mod tests {
         let tags = cmd!("git", "tag", "-l").dir(path).read()?;
 
         Ok(tags)
+    }
+
+    fn get_last_commit(path: &str) -> Result<String, Box<dyn Error>> {
+        let commit_sha = cmd!("git", "rev-parse", "HEAD").dir(path).read()?;
+
+        Ok(commit_sha)
     }
 
     fn cleanup_repository(local: &str) -> Result<(), Box<dyn Error>> {
@@ -266,6 +321,21 @@ mod tests {
         let is_pulled = check.check_inner(&mut context)?;
         assert!(!is_pulled);
 
+        // It should set the context keys
+        let commit_sha = get_last_commit(&local)?;
+        let remote_path = fs::canonicalize(format!("{local}-remote"))?;
+        let remote = remote_path.to_str().unwrap();
+        assert_eq!("branch", context.get("GIT_REF_TYPE").unwrap());
+        assert_eq!("refs/heads/master", context.get("GIT_REF_NAME").unwrap());
+        assert_eq!("master", context.get("GIT_BRANCH_NAME").unwrap());
+        assert_eq!(&commit_sha, context.get("GIT_BEFORE_COMMIT_SHA").unwrap());
+        assert_eq!(
+            &commit_sha[0..7],
+            context.get("GIT_BEFORE_COMMIT_SHORT_SHA").unwrap()
+        );
+        assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
+        assert_eq!(remote, context.get("GIT_REMOTE_URL").unwrap());
+
         cleanup_repository(&local)?;
 
         Ok(())
@@ -281,6 +351,7 @@ mod tests {
         // Create another repository and push a new commit
         create_other_repository(&local)?;
 
+        let before_commit_sha = get_last_commit(&local)?;
         let mut check = GitCheck::open(&local)?;
         let mut context: HashMap<String, String> = HashMap::new();
         let is_pulled = check.check_inner(&mut context)?;
@@ -288,6 +359,29 @@ mod tests {
 
         // The pushed file should be pulled
         assert!(Path::new(&format!("{local}/2")).exists());
+
+        // It should set the context keys
+        let remote_path = fs::canonicalize(format!("{local}-remote"))?;
+        let remote = remote_path.to_str().unwrap();
+        let commit_sha = get_last_commit(&local)?;
+        assert_eq!("branch", context.get("GIT_REF_TYPE").unwrap());
+        assert_eq!("refs/heads/master", context.get("GIT_REF_NAME").unwrap());
+        assert_eq!("master", context.get("GIT_BRANCH_NAME").unwrap());
+        assert_eq!(
+            &before_commit_sha,
+            context.get("GIT_BEFORE_COMMIT_SHA").unwrap()
+        );
+        assert_eq!(
+            &before_commit_sha[0..7],
+            context.get("GIT_BEFORE_COMMIT_SHORT_SHA").unwrap()
+        );
+        assert_eq!(&commit_sha, context.get("GIT_COMMIT_SHA").unwrap());
+        assert_eq!(
+            &commit_sha[0..7],
+            context.get("GIT_COMMIT_SHORT_SHA").unwrap()
+        );
+        assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
+        assert_eq!(remote, context.get("GIT_REMOTE_URL").unwrap());
 
         cleanup_repository(&local)?;
 

--- a/src/checks/git/repository.rs
+++ b/src/checks/git/repository.rs
@@ -5,11 +5,38 @@ use git2::{
 };
 use log::{debug, trace};
 
+pub enum GitRepositoryInformation {
+    Branch {
+        ref_type: String,
+        ref_name: String,
+        branch_name: String,
+        commit_sha: String,
+        commit_short_sha: String,
+        remote_name: String,
+        remote_url: String,
+    },
+    Reference {
+        ref_type: String,
+        ref_name: String,
+        commit_sha: String,
+        commit_short_sha: String,
+    },
+}
+
+/// A directory that is opened as a git repository.
+/// 
+/// It is a wrapper around the underlying `git2` [Repository](git2::Repository).
 pub struct GitRepository {
     repo: Repository,
 }
 
+/// Return the 7 characters short hash version for a commit SHA
+pub fn shorthash(sha: &str) -> String {
+    sha[0..7].to_string()
+}
+
 impl GitRepository {
+    /// Open a directory as a GitRepository. Fails if the directory, is not a valid git repo.
     pub fn open(directory: &str) -> Result<Self, GitError> {
         let repo = Repository::open(directory)
             .map_err(|_| GitError::NotAGitRepository(String::from(directory)))?;
@@ -17,25 +44,72 @@ impl GitRepository {
         Ok(GitRepository { repo })
     }
 
+    /// Get information about the current repository, for context and usage in GitRepository
+    pub fn get_repository_information(&self) -> Result<GitRepositoryInformation, GitError> {
+        let Self { repo, .. } = self;
+        let head = repo.head().map_err(|_| GitError::NotOnABranch)?;
+        let ref_name = head.name().ok_or(GitError::NotOnABranch)?;
+        let commit_sha = head
+            .peel_to_commit()
+            .map_err(|_| GitError::NotOnABranch)?
+            .id()
+            .to_string();
+
+        let branch_name = head.shorthand();
+        if let Some(branch_name) = branch_name {
+            let remote_buf = repo
+                .branch_upstream_remote(ref_name)
+                .map_err(|_| GitError::NoRemoteForBranch(String::from(branch_name)))?;
+            let remote_name = remote_buf
+                .as_str()
+                .ok_or_else(|| GitError::NoRemoteForBranch(String::from(branch_name)))?;
+
+            let remote = repo
+                .find_remote(remote_name)
+                .map_err(|_| GitError::NoRemoteForBranch(String::from(branch_name)))?;
+
+            let remote_url = remote
+                .url()
+                .ok_or(GitError::NoRemoteForBranch(String::from(branch_name)))?;
+
+            Ok(GitRepositoryInformation::Branch {
+                ref_type: "branch".to_string(),
+                ref_name: ref_name.to_string(),
+                branch_name: branch_name.to_string(),
+                commit_short_sha: shorthash(&commit_sha),
+                commit_sha,
+                remote_url: remote_url.to_string(),
+                remote_name: remote_name.to_string(),
+            })
+        } else {
+            Ok(GitRepositoryInformation::Reference {
+                ref_type: "reference".to_string(),
+                ref_name: ref_name.to_string(),
+                commit_short_sha: shorthash(&commit_sha),
+                commit_sha,
+            })
+        }
+    }
+
     // Inspired from: https://github.com/rust-lang/git2-rs/blob/master/examples/pull.rs
     pub fn fetch(&self) -> Result<AnnotatedCommit, GitError> {
         let Self { repo, .. } = self;
-        let head = repo.head().map_err(|_| GitError::NotOnABranch)?;
-        let branch_name = head.shorthand().ok_or(GitError::NotOnABranch)?;
-        let branch_name_ref = head.name().ok_or(GitError::NotOnABranch)?;
-        let remote_buf = repo
-            .branch_upstream_remote(branch_name_ref)
-            .map_err(|_| GitError::NoRemoteForBranch(String::from(branch_name)))?;
-        let remote_name = remote_buf
-            .as_str()
-            .ok_or_else(|| GitError::NoRemoteForBranch(String::from(branch_name)))?;
-
-        let mut remote = repo
-            .find_remote(remote_name)
-            .map_err(|_| GitError::NoRemoteForBranch(String::from(branch_name)))?;
+        let (branch_name, remote_name) = match self.get_repository_information()? {
+            GitRepositoryInformation::Branch {
+                branch_name,
+                remote_name,
+                ..
+            } => Ok((branch_name, remote_name)),
+            GitRepositoryInformation::Reference { .. } => Err(GitError::NotOnABranch),
+        }?;
 
         trace!("Trying to fetch {branch_name} from {remote_name}.");
 
+        let mut remote = repo
+            .find_remote(&remote_name)
+            .map_err(|_| GitError::NoRemoteForBranch(branch_name.clone()))?;
+
+        // Setup authentication callbacks to fetch the repository
         let mut cb = RemoteCallbacks::new();
         let git_config = Config::open_default().map_err(|_| GitError::ConfigLoadingFailed)?;
         let mut ch = CredentialHandler::new(git_config);
@@ -48,10 +122,12 @@ impl GitRepository {
             try_cred
         });
 
+        // Set option to download tags automatically
         let mut opts = FetchOptions::new();
         opts.remote_callbacks(cb);
         opts.download_tags(AutotagOption::Auto);
 
+        // Fetch the remote state
         remote
             .fetch(&[branch_name], Some(&mut opts), None)
             .map_err(|_| GitError::FetchFailed)?;
@@ -98,8 +174,14 @@ impl GitRepository {
 
     pub fn pull(&self, fetch_commit: &AnnotatedCommit) -> Result<bool, GitError> {
         let Self { repo, .. } = self;
-        let head = repo.head().map_err(|_| GitError::NotOnABranch)?;
-        let branch_name = head.shorthand().ok_or(GitError::NotOnABranch)?;
+        let (branch_name, ref_name) = match self.get_repository_information()? {
+            GitRepositoryInformation::Branch {
+                branch_name,
+                ref_name,
+                ..
+            } => Ok((branch_name, ref_name)),
+            GitRepositoryInformation::Reference { .. } => Err(GitError::NotOnABranch),
+        }?;
 
         trace!("Pulling {branch_name}.");
 
@@ -111,31 +193,23 @@ impl GitRepository {
             return Err(GitError::DirtyWorkingTree);
         }
 
-        let branch_refname = format!("refs/heads/{}", branch_name);
-        let branch_ref = repo
-            .find_reference(&branch_refname)
-            .map_err(|_| GitError::NotOnABranch)?;
-
-        let name = branch_ref
-            .name()
-            .ok_or_else(|| GitError::NoRemoteForBranch(String::from(branch_name)))?;
         let msg = format!(
             "Fast-Forward: Setting {} to id: {}.",
-            name,
+            ref_name,
             fetch_commit.id()
         );
 
-        let fetch_short = &fetch_commit.id().to_string()[0..7];
-        trace!("Setting {} to id: {}.", name, fetch_short);
+        let fetch_short = shorthash(&fetch_commit.id().to_string());
+        trace!("Setting {} to id: {}.", ref_name, fetch_short);
 
         let mut branch_ref = repo
-            .find_reference(&branch_refname)
+            .find_reference(&ref_name)
             .map_err(|_| GitError::NotOnABranch)?;
         let fetch_id = fetch_commit.id();
         branch_ref
             .set_target(fetch_id, &msg)
             .map_err(|_| GitError::FailedSettingHead(fetch_short.to_string()))?;
-        repo.set_head(name)
+        repo.set_head(&ref_name)
             .map_err(|_| GitError::FailedSettingHead(fetch_short.to_string()))?;
         repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
             .map_err(|_| GitError::FailedSettingHead(fetch_short.to_string()))?;

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use mockall::automock;
 use thiserror::Error;
 
@@ -16,7 +18,7 @@ pub enum CheckError {
     #[error("permission denied: {0}")]
     PermissionDenied(String),
     /// Cannot update the check, because there is a conflict.
-	/// This can be a merge conflict, a filesystem issue
+    /// This can be a merge conflict, a filesystem issue
     #[error("there is a conflict: {0}")]
     Conflict(String),
     /// Running the trigger failed.
@@ -33,5 +35,5 @@ pub enum CheckError {
 #[automock]
 pub trait Check {
     /// Check if there are changes and update if necessary.
-    fn check(&mut self) -> Result<bool, CheckError>;
+    fn check(&mut self, context: &mut HashMap<String, String>) -> Result<bool, CheckError>;
 }

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use crate::context::Context;
 use mockall::automock;
 use thiserror::Error;
 
@@ -35,5 +34,5 @@ pub enum CheckError {
 #[automock]
 pub trait Check {
     /// Check if there are changes and update if necessary.
-    fn check(&mut self, context: &mut HashMap<String, String>) -> Result<bool, CheckError>;
+    fn check(&mut self, context: &mut Context) -> Result<bool, CheckError>;
 }

--- a/src/checks/watch.rs
+++ b/src/checks/watch.rs
@@ -1,11 +1,12 @@
 use super::{Check, CheckError};
-use std::{collections::HashMap, result::Result};
+use crate::context::Context;
+use std::result::Result;
 
 /// A check to watch a directory for changes.
 pub struct WatchCheck;
 
 impl Check for WatchCheck {
-    fn check(&mut self, _context: &mut HashMap<String, String>) -> Result<bool, CheckError> {
+    fn check(&mut self, _context: &mut Context) -> Result<bool, CheckError> {
         todo!()
     }
 }

--- a/src/checks/watch.rs
+++ b/src/checks/watch.rs
@@ -1,11 +1,11 @@
 use super::{Check, CheckError};
-use std::result::Result;
+use std::{collections::HashMap, result::Result};
 
 /// A check to watch a directory for changes.
 pub struct WatchCheck;
 
 impl Check for WatchCheck {
-    fn check(&mut self) -> Result<bool, CheckError> {
+    fn check(&mut self, _context: &mut HashMap<String, String>) -> Result<bool, CheckError> {
         todo!()
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,3 @@
+use std::collections::HashMap;
+
+pub type Context = HashMap<&'static str, String>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,13 @@
 pub mod actions;
 /// A check is a process that tests if there are any changes and updates it.
 pub mod checks;
-/// The main program loop, that runs the triggers, checks and actions infinitely.
-pub mod start;
 /// A trigger is a long running background process, which initiates the checks
 /// (e.g. [on a schedule](triggers::schedule::ScheduleTrigger), [on HTTP request](triggers::http::HttpTrigger)
 /// or [once](triggers::once::OnceTrigger)).
 pub mod triggers;
+
+/// The main program loop, that runs the triggers, checks and actions infinitely.
+pub mod start;
+
+/// The context which can share data between the different steps.
+pub mod context;

--- a/src/start.rs
+++ b/src/start.rs
@@ -1,10 +1,11 @@
 use crate::{
     actions::Action,
     checks::{Check, CheckError},
+    context::Context,
     triggers::{Trigger, TriggerError},
 };
 use log::{debug, error};
-use std::{collections::HashMap, sync::mpsc, thread};
+use std::{sync::mpsc, thread};
 use thiserror::Error;
 
 /// A custom error implementation for the start function
@@ -24,7 +25,7 @@ pub fn start(
     check: &mut Box<dyn Check>,
     actions: &[Box<dyn Action>],
 ) -> Result<(), StartError> {
-    let (tx, rx) = mpsc::channel::<Option<HashMap<String, String>>>();
+    let (tx, rx) = mpsc::channel::<Option<Context>>();
 
     if triggers.is_empty() {
         return Err(StartError::NoTriggers);
@@ -69,6 +70,7 @@ mod tests {
         checks::{Check, MockCheck},
         triggers::{MockTrigger, Trigger},
     };
+    use std::collections::HashMap;
 
     #[test]
     fn it_should_call_once() {

--- a/src/triggers/http.rs
+++ b/src/triggers/http.rs
@@ -56,8 +56,8 @@ impl HttpTrigger {
 
             let context: HashMap<String, String> = [
                 ("TRIGGER_NAME", TRIGGER_NAME),
-                ("TRIGGER_HTTP_METHOD", request.method().as_str()),
-                ("TRIGGER_HTTP_URL", request.url()),
+                ("HTTP_METHOD", request.method().as_str()),
+                ("HTTP_URL", request.url()),
             ]
             .into_iter()
             .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
@@ -120,14 +120,14 @@ mod tests {
         let msg = rx.recv()?;
         let context = msg.unwrap();
         assert_eq!(TRIGGER_NAME, context.get("TRIGGER_NAME").unwrap());
-        assert_eq!("GET", context.get("TRIGGER_HTTP_METHOD").unwrap());
-        assert_eq!("/", context.get("TRIGGER_HTTP_URL").unwrap());
+        assert_eq!("GET", context.get("HTTP_METHOD").unwrap());
+        assert_eq!("/", context.get("HTTP_URL").unwrap());
 
         let msg = rx.recv()?;
         let context = msg.unwrap();
         assert_eq!(TRIGGER_NAME, context.get("TRIGGER_NAME").unwrap());
-        assert_eq!("POST", context.get("TRIGGER_HTTP_METHOD").unwrap());
-        assert_eq!("/trigger", context.get("TRIGGER_HTTP_URL").unwrap());
+        assert_eq!("POST", context.get("HTTP_METHOD").unwrap());
+        assert_eq!("/trigger", context.get("HTTP_URL").unwrap());
 
         Ok(())
     }

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -1,5 +1,6 @@
+use crate::context::Context;
 use mockall::automock;
-use std::{collections::HashMap, sync::mpsc::Sender};
+use std::sync::mpsc::Sender;
 use thiserror::Error;
 
 /// A trigger that runs on an HTTP request.
@@ -17,7 +18,7 @@ pub enum TriggerError {
     Misconfigured(String),
     /// Cannot send trigger with Sender. This usually because the receiver is dropped.
     #[error("cannot trigger changes, receiver hang up")]
-    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<HashMap<String, String>>>),
+    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<Context>>),
     /// Running the trigger failed.
     #[error("{0}")]
     FailedTrigger(String),
@@ -32,5 +33,5 @@ pub enum TriggerError {
 #[automock]
 pub trait Trigger: Sync + Send {
     /// Start the trigger process.
-    fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError>;
+    fn listen(&self, tx: Sender<Option<Context>>) -> Result<(), TriggerError>;
 }

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -1,5 +1,5 @@
 use mockall::automock;
-use std::sync::mpsc::Sender;
+use std::{collections::HashMap, sync::mpsc::Sender};
 use thiserror::Error;
 
 /// A trigger that runs on an HTTP request.
@@ -17,7 +17,7 @@ pub enum TriggerError {
     Misconfigured(String),
     /// Cannot send trigger with Sender. This usually because the receiver is dropped.
     #[error("cannot trigger changes, receiver hang up")]
-    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<()>>),
+    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<HashMap<String, String>>>),
     /// Running the trigger failed.
     #[error("{0}")]
     FailedTrigger(String),
@@ -32,5 +32,5 @@ pub enum TriggerError {
 #[automock]
 pub trait Trigger: Sync + Send {
     /// Start the trigger process.
-    fn listen(&self, tx: Sender<Option<()>>) -> Result<(), TriggerError>;
+    fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError>;
 }

--- a/src/triggers/once.rs
+++ b/src/triggers/once.rs
@@ -1,15 +1,16 @@
 use super::{Trigger, TriggerError};
 use log::info;
-use std::sync::mpsc::Sender;
+use std::{collections::HashMap, sync::mpsc::Sender};
 
 /// A trigger that runs the checks once and then exits.
 pub struct OnceTrigger;
 
 impl Trigger for OnceTrigger {
     /// Starts a trigger that runs once and terminates after.
-    fn listen(&self, tx: Sender<Option<()>>) -> Result<(), TriggerError> {
+    fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError> {
         info!("Triggering only once.");
-        tx.send(Some(()))?;
+        let context: HashMap<String, String> = HashMap::new();
+        tx.send(Some(context))?;
         tx.send(None)?;
         Ok(())
     }
@@ -23,11 +24,11 @@ mod tests {
     #[test]
     fn it_should_trigger_once_and_stop() {
         let trigger = OnceTrigger;
-        let (tx, rx) = mpsc::channel::<Option<()>>();
+        let (tx, rx) = mpsc::channel::<Option<HashMap<String, String>>>();
 
         trigger.listen(tx).unwrap();
 
         let msgs: Vec<_> = rx.iter().collect();
-        assert_eq!(vec![Some(()), None], msgs);
+        assert_eq!(vec![Some(HashMap::new()), None], msgs);
     }
 }

--- a/src/triggers/once.rs
+++ b/src/triggers/once.rs
@@ -2,6 +2,8 @@ use super::{Trigger, TriggerError};
 use log::info;
 use std::{collections::HashMap, sync::mpsc::Sender};
 
+const TRIGGER_NAME: &str = "ONCE";
+
 /// A trigger that runs the checks once and then exits.
 pub struct OnceTrigger;
 
@@ -9,7 +11,8 @@ impl Trigger for OnceTrigger {
     /// Starts a trigger that runs once and terminates after.
     fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError> {
         info!("Triggering only once.");
-        let context: HashMap<String, String> = HashMap::new();
+        let context: HashMap<String, String> =
+            HashMap::from([("TRIGGER_NAME".to_string(), TRIGGER_NAME.to_string())]);
         tx.send(Some(context))?;
         tx.send(None)?;
         Ok(())
@@ -29,6 +32,15 @@ mod tests {
         trigger.listen(tx).unwrap();
 
         let msgs: Vec<_> = rx.iter().collect();
-        assert_eq!(vec![Some(HashMap::new()), None], msgs);
+        assert_eq!(
+            vec![
+                Some(HashMap::from([(
+                    "TRIGGER_NAME".to_string(),
+                    TRIGGER_NAME.to_string()
+                )])),
+                None
+            ],
+            msgs
+        );
     }
 }

--- a/src/triggers/once.rs
+++ b/src/triggers/once.rs
@@ -1,4 +1,5 @@
 use super::{Trigger, TriggerError};
+use crate::context::Context;
 use log::info;
 use std::{collections::HashMap, sync::mpsc::Sender};
 
@@ -9,10 +10,9 @@ pub struct OnceTrigger;
 
 impl Trigger for OnceTrigger {
     /// Starts a trigger that runs once and terminates after.
-    fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError> {
+    fn listen(&self, tx: Sender<Option<Context>>) -> Result<(), TriggerError> {
         info!("Triggering only once.");
-        let context: HashMap<String, String> =
-            HashMap::from([("TRIGGER_NAME".to_string(), TRIGGER_NAME.to_string())]);
+        let context: Context = HashMap::from([("TRIGGER_NAME", TRIGGER_NAME.to_string())]);
         tx.send(Some(context))?;
         tx.send(None)?;
         Ok(())
@@ -27,17 +27,14 @@ mod tests {
     #[test]
     fn it_should_trigger_once_and_stop() {
         let trigger = OnceTrigger;
-        let (tx, rx) = mpsc::channel::<Option<HashMap<String, String>>>();
+        let (tx, rx) = mpsc::channel::<Option<Context>>();
 
         trigger.listen(tx).unwrap();
 
         let msgs: Vec<_> = rx.iter().collect();
         assert_eq!(
             vec![
-                Some(HashMap::from([(
-                    "TRIGGER_NAME".to_string(),
-                    TRIGGER_NAME.to_string()
-                )])),
+                Some(HashMap::from([("TRIGGER_NAME", TRIGGER_NAME.to_string())])),
                 None
             ],
             msgs

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -1,4 +1,5 @@
 use super::{Trigger, TriggerError};
+use crate::context::Context;
 use duration_string::DurationString;
 use log::info;
 use std::{
@@ -24,7 +25,7 @@ pub struct ScheduleTrigger {
 pub enum ScheduleError {
     /// Cannot send trigger with Sender. This usually because the receiver is dropped.
     #[error("cannot trigger changes, receiver hang up")]
-    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<HashMap<String, String>>>),
+    ReceiverHangup(#[from] std::sync::mpsc::SendError<Option<Context>>),
 }
 
 impl From<ScheduleError> for TriggerError {
@@ -58,15 +59,15 @@ impl ScheduleTrigger {
     /// wait until the end of the timeout and returns with false.
     pub fn step(
         &self,
-        tx: Sender<Option<HashMap<String, String>>>,
+        tx: Sender<Option<Context>>,
         final_timeout: Option<Instant>,
     ) -> Result<bool, ScheduleError> {
         let next_check = Instant::now() + self.duration;
 
-        let context: HashMap<String, String> = HashMap::from([
-            ("TRIGGER_NAME".to_string(), TRIGGER_NAME.to_string()),
+        let context: Context = HashMap::from([
+            ("TRIGGER_NAME", TRIGGER_NAME.to_string()),
             (
-                "SCHEDULE_DURATION".to_string(),
+                "SCHEDULE_DURATION",
                 DurationString::from(self.duration).to_string(),
             ),
         ]);
@@ -91,7 +92,7 @@ impl Trigger for ScheduleTrigger {
     /// Every step triggers and then waits the given duration. In case of an error,
     /// it terminates or if it will reach the final timeout it will wait until
     /// the end of the timeout and return.
-    fn listen(&self, tx: Sender<Option<HashMap<String, String>>>) -> Result<(), TriggerError> {
+    fn listen(&self, tx: Sender<Option<Context>>) -> Result<(), TriggerError> {
         let final_timeout = self.timeout.map(|t| Instant::now() + t);
         info!(
             "Starting schedule in every {}.",
@@ -135,7 +136,7 @@ mod tests {
     #[test]
     fn it_should_trigger_every_100_ms() -> Result<(), TriggerError> {
         let trigger = ScheduleTrigger::new(Duration::from_millis(100));
-        let (tx, rx) = mpsc::channel::<Option<HashMap<String, String>>>();
+        let (tx, rx) = mpsc::channel::<Option<Context>>();
 
         for _ in 0..5 {
             let start = Instant::now();
@@ -161,7 +162,7 @@ mod tests {
     #[test]
     fn it_should_not_continue_after_the_timeout() -> Result<(), TriggerError> {
         let trigger = ScheduleTrigger::new(Duration::from_millis(100));
-        let (tx, _rx) = mpsc::channel::<Option<HashMap<String, String>>>();
+        let (tx, _rx) = mpsc::channel::<Option<Context>>();
 
         let final_timeout = Instant::now() + Duration::from_millis(350);
         for i in 0..5 {
@@ -186,7 +187,7 @@ mod tests {
     #[test]
     fn it_should_not_trigger_on_a_send_error() {
         let trigger = ScheduleTrigger::new(Duration::from_millis(100));
-        let (tx, rx) = mpsc::channel::<Option<HashMap<String, String>>>();
+        let (tx, rx) = mpsc::channel::<Option<Context>>();
 
         // Close receiving end, to create a send error
         drop(rx);

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -66,7 +66,7 @@ impl ScheduleTrigger {
         let context: HashMap<String, String> = HashMap::from([
             ("TRIGGER_NAME".to_string(), TRIGGER_NAME.to_string()),
             (
-                "TRIGGER_SCHEDULE_DURATION".to_string(),
+                "SCHEDULE_DURATION".to_string(),
                 DurationString::from(self.duration).to_string(),
             ),
         ]);
@@ -152,7 +152,7 @@ mod tests {
             // It should contain the hashmap
             let context = msg.unwrap();
             assert_eq!(TRIGGER_NAME, context.get("TRIGGER_NAME").unwrap());
-            assert_eq!("100ms", context.get("TRIGGER_SCHEDULE_DURATION").unwrap());
+            assert_eq!("100ms", context.get("SCHEDULE_DURATION").unwrap());
         }
 
         Ok(())

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -67,7 +67,7 @@ impl ScheduleTrigger {
         let context: Context = HashMap::from([
             ("TRIGGER_NAME", TRIGGER_NAME.to_string()),
             (
-                "SCHEDULE_DURATION",
+                "SCHEDULE_DELAY",
                 DurationString::from(self.duration).to_string(),
             ),
         ]);
@@ -153,7 +153,7 @@ mod tests {
             // It should contain the hashmap
             let context = msg.unwrap();
             assert_eq!(TRIGGER_NAME, context.get("TRIGGER_NAME").unwrap());
-            assert_eq!("100ms", context.get("SCHEDULE_DURATION").unwrap());
+            assert_eq!("100ms", context.get("SCHEDULE_DELAY").unwrap());
         }
 
         Ok(())


### PR DESCRIPTION
- Add canonicalizing to main for better logging
- Set the environment variables for scripts
- Add context information to git check
- Change context keys to shorter variants
- Add context settings to triggers
- Scaffold context implementation
