### PR TITLE
Add subprocess handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **New feature**: Subprocess handling
+  - Use `-p` to start a process directly and restart on change
+  - Configure the retries to restart the process in case of a failure
+  - Set the stop signal and stop timeout args to configure graceful shutdown before restart
+
 ### Changed
 
 - Only change gitconfig (safe.directory) if there isn't one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "mockall",
  "nix",
  "rand",
+ "shlex",
  "signal-hook",
  "simple_logger",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +208,7 @@ dependencies = [
  "libgit2-sys",
  "log",
  "mockall",
+ "nix",
  "rand",
  "signal-hook",
  "simple_logger",
@@ -333,6 +340,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libgit2-sys = "0.17.0"
 log = "0.4.20"
 mockall = "0.13.0"
 nix = { version = "0.29.0", features = ["signal"] }
+shlex = "1.3.0"
 signal-hook = "0.3.17"
 simple_logger = "5.0.0"
 thiserror = "1.0.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ gumdrop = "0.8.1"
 libgit2-sys = "0.17.0"
 log = "0.4.20"
 mockall = "0.13.0"
+nix = { version = "0.29.0", features = ["signal"] }
 signal-hook = "0.3.17"
 simple_logger = "5.0.0"
 thiserror = "1.0.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/daniel7grant/gw"
 
 [dependencies]
 dirs = "5.0.1"
+duct = "0.13.7"
 duct_sh = "0.13.7"
 duration-string = "0.4.0"
 git2 = "0.19.0"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This will run every time there is a new commit, and after the pull it will print
 ```sh
 $ gw . -v --script 'cat DATETIME'
 # ...
-2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running scripts.
+2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
 2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /home/grant/Development/quick/time.
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Watch local git repositories, keep in sync with remote and run commands.
 `gw` is a lightweight binary that manages a simple pull-based continuous deployment for you. It watches a local git repository, fetches if the remote changes, and builds or deploys your code. Current CD solutions either lock you into proprietary software (e.g. Netlify or Vercel) or complicated to run and manage (e.g. ArgoCD). `gw` is a service that can run everywhere (even behind NAT or VPN), synchronizes code with your remote and deploys immediately, saving your developers time and energy.
 
 Features of `gw`:
-- **lightweight**: it is only a 2.5MB binary (~7MB with git and ssh statically built-in)
+- **lightweight**: it is only a 1.5MB binary (~7MB with git and ssh statically built-in)
 - **runs anywhere**: use it on baremetal, [systemd](https://gw.danielgrants.com/usage/systemd.md) or [docker](https://gw.danielgrants.com/usage/docker.md)
 - **open source**: written entirely in Rust, you can build it from source in a few minutes
 - **pull-based**: works on any network, even behind a NAT or VPN

--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ $ gw . -v --script 'cat DATETIME'
 
 You can add multiple scripts, which will run one after another. Use these scripts to build source files, restarts deployments and anything else that you can imagine.
 
+### Run subprocess, restart on pull
+
+It is often enough to run scripts, but many times you also want to maintain a long-running process e.g. for web services. `gw` can help you with this, using the `-p` flag. This will start a process in the background and restart it on pull.
+
+For example starting a python web server:
+
+```sh
+$ gw . -v -p "python -m http.server"
+# ...
+2024-10-06T21:58:21.306Z DEBUG [gw] Setting up ProcessAction "python -m http.server" on change.
+2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /home/grant/Development/grant/gw.
+2024-10-06T21:58:56.211Z DEBUG [gw_bin::actions::process] [python] Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+```
+
+This will run a python process in the background and stop and start it again if a git pull happened. Just wrap your deployment script with `gw` and see it gets updated every time you push to git.
+
 ## Next steps
 
 If you like `gw`, there are multiple ways to use it for real-life use-cases.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ cd time
 To get started, point `gw` to this local repository. By default it pulls the changes every minute. We can add the `--verbose` or `-v` flag to see when the changes occur:
 
 ```sh
-gw . -v
+gw /path/to/repo -v
 ```
 
 If you are using your own repository, create a commit in a different place, and see how it gets automatically pulled (in the case of the `time` repo, there is a commit every minute). The verbose logs should print that a git pull happened:
 
 ```sh
-$ gw . -v
+$ gw /path/to/repo -v
 # ...
 2024-03-10T14:48:13.447Z DEBUG [gw_bin::checks::git::repository] Checked out fc23d21 on branch main.
 2024-03-10T14:48:13.447Z INFO  [gw_bin::start] There are updates, pulling.
@@ -72,16 +72,16 @@ git log -1  # it should be a commit in the last minute
 Pulling files automatically is useful but the `--script` or `-s` flag unlocks `gw`'s potential: it can run any kind of custom script if there are any changes. For a simple example, we can print the content of a file to the log with `cat`:
 
 ```sh
-gw . -v --script 'cat DATETIME'
+gw /path/to/repo -v --script 'cat DATETIME'
 ```
 
 This will run every time there is a new commit, and after the pull it will print the file contents. You can see that the results are printed in the log:
 
 ```sh
-$ gw . -v --script 'cat DATETIME'
+$ gw /path/to/repo -v --script 'cat DATETIME'
 # ...
 2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
-2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /home/grant/Development/quick/time.
+2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /path/to/repo.
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000
 ```
@@ -95,10 +95,10 @@ It is often enough to run scripts, but many times you also want to maintain a lo
 For example starting a python web server:
 
 ```sh
-$ gw . -v -p "python -m http.server"
+$ gw /path/to/repo -v -p "python -m http.server"
 # ...
 2024-10-06T21:58:21.306Z DEBUG [gw] Setting up ProcessAction "python -m http.server" on change.
-2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /home/grant/Development/grant/gw.
+2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /path/to/repo.
 2024-10-06T21:58:56.211Z DEBUG [gw_bin::actions::process] [python] Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 ```
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -14,7 +14,7 @@ Watch local git repositories, keep in sync with remote and run commands.
 `gw` is a lightweight binary that manages a simple pull-based continuous deployment for you. It watches a local git repository, fetches if the remote changes, and builds or deploys your code. Current CD solutions either lock you into proprietary software (e.g. Netlify or Vercel) or complicated to run and manage (e.g. ArgoCD). `gw` is a service that can run everywhere (even behind NAT or VPN), synchronizes code with your remote and deploys immediately, saving your developers time and energy.
 
 Features of `gw`:
-- **lightweight**: it is only a 2.5MB binary (~7MB with git and ssh statically built-in)
+- **lightweight**: it is only a 1.5MB binary (~7MB with git and ssh statically built-in)
 - **runs anywhere**: use it on baremetal, [systemd](/usage/systemd) or [docker](/usage/docker)
 - **open source**: written entirely in Rust, you can build it from source in a few minutes
 - **pull-based**: works on any network, even behind a NAT or VPN

--- a/docs/content/guides/compiled.md
+++ b/docs/content/guides/compiled.md
@@ -11,10 +11,32 @@ For compiled (Go, Rust) or transpiled (TypeScript) you can use `gw` to build new
 
 Simply add the scripts to build the binary then another one to restart it and watch the repository.
 
-For example for TS and PM2:
+### TypeScript
+
+For example for TypeScript, transpile to JS and run with Node.js:
 
 ```sh
-gw /path/to/repo -s 'npm run build' -s 'npx pm2 restart'
+gw /path/to/repo -s 'npx tsc -p tsconfig.json' -p 'node dist/index.js'
+```
+
+### Go
+
+For Go, you can either run it directly or build it first and run it as a subprocess:
+
+```sh
+gw /path/to/repo -p 'go run main.go'
+# or 
+gw /path/to/repo -s 'go build main.go' -p './main'
+```
+
+### Rust
+
+For Rust, you can either run it directly or build it first and run it as a subprocess:
+
+```sh
+gw /path/to/repo -p 'cargo run --release'
+# or 
+gw /path/to/repo -s 'cargo build --release' -p './target/release/repo'
 ```
 
 Also checkout [Docker configuration](/guides/docker-compose).

--- a/docs/content/guides/compiled.md
+++ b/docs/content/guides/compiled.md
@@ -1,6 +1,6 @@
 +++
 title = "Compiled languages"
-weight = 2
+weight = 3
 +++
 
 # Compiled languages
@@ -17,6 +17,12 @@ For example for TypeScript, transpile to JS and run with Node.js:
 
 ```sh
 gw /path/to/repo -s 'npx tsc -p tsconfig.json' -p 'node dist/index.js'
+```
+
+For Next.js and other frameworks that require a build step before starting, you can use:
+
+```sh
+gw /path/to/repo -s 'npm run build' -p 'npm run start'
 ```
 
 ### Go

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -1,6 +1,6 @@
 +++
 title = "Configuration files"
-weight = 4
+weight = 5
 +++
 
 # Configuration files

--- a/docs/content/guides/configuration.md
+++ b/docs/content/guides/configuration.md
@@ -43,6 +43,12 @@ gw /etc/nginx -s 'nginx -s reload'
 gw /etc/nginx -s 'systemctl reload nginx'
 ```
 
+You can also run `nginx` as a subprocess if you don't want to manage it separately, but this will stop and restart it every time a pull occurs:
+
+```sh
+gw /etc/nginx -p "nginx -g 'daemon off;'"
+```
+
 If you want to avoid getting your system into a bad state by mistake, you can test the config files first with `nginx -t`:
 
 ```sh

--- a/docs/content/guides/development.md
+++ b/docs/content/guides/development.md
@@ -12,7 +12,7 @@ You can use `gw` to help in local development. You can pull your repository cont
 Simply set the path to your repository:
 
 ```sh
-gw /path/to/repo -s 'npm run build' -s 'npx pm2 restart'
+gw /path/to/repo
 ```
 
 You can use the `notify-send` command to popup notifications on Linux, let's use it to show if somebody commited to our branch.

--- a/docs/content/guides/development.md
+++ b/docs/content/guides/development.md
@@ -1,11 +1,13 @@
 +++
 title = "Local development"
-weight = 5
+weight = 6
 +++
 
 # Local development
 
 You can use `gw` to help in local development. You can pull your repository continuously, so in case somebody commits (and there is no conflicts) you can get the newest version. You can also set a notification to see immediately if somebody modified anything.
+
+> I don't recommend working on the same branch with multiple people, but sometimes it happens.
 
 ## Configuration
 

--- a/docs/content/guides/docker-compose.md
+++ b/docs/content/guides/docker-compose.md
@@ -1,6 +1,6 @@
 +++
 title = "Docker Compose"
-weight = 3
+weight = 4
 +++
 
 # Docker Compose

--- a/docs/content/guides/dynamic.md
+++ b/docs/content/guides/dynamic.md
@@ -1,0 +1,38 @@
++++
+title = "Dynamic languages"
+weight = 2
++++
+
+# Dynamic languages
+
+For dynamic languages you can use `gw` very simply with [processes](/usage/actions#processes).
+
+## Configuration
+
+Wrap the way you normally start your program with the `--process` flag.
+
+### Node.js
+
+For example for Node.js programs, use the usual `npm run start` script with a process:
+
+```sh
+gw /path/to/repo -p 'npm run start'
+```
+
+If you want to use a build step, for example for TypeScript look at the [TypeScript guide](/guides/compiled#typescript).
+
+### Python
+
+Use the same idea with Python, wrap your program's entrypoint in a process:
+
+```sh
+gw /path/to/repo -p 'python manage.py runserver'
+```
+
+### Ruby
+
+Same thing with Ruby, add process to your program's entrypoint:
+
+```sh
+gw /path/to/repo -p 'bin/rails server'
+```

--- a/docs/content/guides/netlify.md
+++ b/docs/content/guides/netlify.md
@@ -1,6 +1,6 @@
 +++
 title = "Netlify alternative"
-weight = 6
+weight = 7
 +++
 
 # Netlify alternative
@@ -26,11 +26,44 @@ npx @11ty/eleventy --input=. --output=output/$GW_GIT_COMMIT_SHORT_SHA
 You can use this command to configure your `gw`:
 
 ```sh
-gw /path/to/directory --script 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA'
+gw /path/to/repo -s 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA'
+```
+
+To build another version for the latest you can copy the files to another folder:
+
+```sh
+gw /path/to/repo -s 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA' -s 'cp -r output/$GW_GIT_COMMIT_SHORT_SHA output/latest'
 ```
 
 ## Web server configuration
 
-One extra setup that you have to do is point your web server to this directory.
+One extra setup that you have to do is point your web server to this directory. By default you can use it as path prefixes, but it can be configured to sub domains to these directories. That way you could reach the commit `0c431ff1` on the url `0c431ff1.example.net`.
 
-By default you can use it as path prefixes, but it can be configured to map to sub domains, for example:
+> Make sure to setup wildcard domains in your DNS server so it redirects all domains to your server!
+
+## Nginx
+
+You can use regexes in `server_name` to rewrite subdomains into different folders. For example this configuration will resolve `0c431ff1.example.net` to `/path/to/repo/0c431ff1`:
+
+```sh
+http {
+    server {
+        # It will capture the subdomain (e.g. 0c431ff1.example.net)
+        server_name ~^([0-9a-f])\.example\.net$;
+
+        location / {
+            # And resolve to /path/to/repo/0c431ff1
+            root /path/to/repo/$1;
+        }
+    }
+
+    # You can add another to reach the latest
+    server {
+        server_name example.net;
+
+        location / {
+            root /path/to/repo/latest;
+        }
+    }
+}
+```

--- a/docs/content/guides/netlify.md
+++ b/docs/content/guides/netlify.md
@@ -43,7 +43,7 @@ One extra setup that you have to do is point your web server to this directory. 
 
 ## Nginx
 
-You can use regexes in `server_name` to rewrite subdomains into different folders. For example this configuration will resolve `0c431ff1.example.net` to `/path/to/repo/0c431ff1`:
+You can use regexes in [server_name](https://nginx.org/en/docs/http/server_names.html) to rewrite subdomains into different folders. For example this configuration will resolve `0c431ff1.example.net` to `/path/to/repo/0c431ff1`:
 
 ```sh
 http {

--- a/docs/content/usage/actions.md
+++ b/docs/content/usage/actions.md
@@ -1,0 +1,78 @@
++++
+title = "Actions on pull"
+weight = 3
++++
+
+# Actions on pull
+
+The main point of `gw` is to do actions every time there code is pulled. There are multiple actions: running a script or restarting a background process.
+
+## Scripts
+
+The simplest action is to run a command on pull with `--script` or `-s`:
+
+```sh
+gw /path/to/repo -s 'echo "updated"'
+```
+
+You can define multiple scripts, these will run one after another (there is currently no way to parallelise these). The output of the script is not printed by default, you can increase verbosity (`-v`) to get output from the script:
+
+```sh
+$ gw /path/to/repo -v -s 'echo "updated"'
+2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
+2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: echo "updated" in directory /path/to/repo.
+2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
+2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   update
+```
+
+Scripts are always run first of all actions and run in a shell (`/bin/sh` on Linux and `cmd` on Windows). This way you can expand variables and use shell features e.g. pipes or multiple commands. The full enviroment is passed to scripts with a number of [gw-specific environment variables](/reference/environment-variables). If you want to use variables make sure to use singlequotes so they aren't expanded beforehand.
+
+```sh
+gw /path/to/repo -s 'ls -l $BUILD_DIRECTORY | wc -l'
+```
+
+Best use-cases for scripts:
+
+- [compile](/guides/compiled) or transpile your code,
+- rebuild some assets,
+- restart or reload a separately running program.
+
+## Processes
+
+If you have some long-running program, you can use `--process` or `-p` to start as a background process and `gw` will restart it on every pull:
+
+```sh
+gw /path/to/repo -p 'ping 1.1.1.1'
+```
+
+Processes are started when `gw` is started and they are kept in the background. If there is a change the process is stopped and a new process is started. If you want to look at the output of process, you have to increase verbosity (`-v`):
+
+```sh
+$ gw /path/to/repo -v -s 'ping 1.1.1.1'
+2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
+2024-10-16T18:04:25.888Z INFO  [gw_bin::actions::process] Starting process "ping" in /path/to/repo.
+2024-10-16T18:04:25.888Z DEBUG [gw_bin::start] Waiting on triggers.
+2024-10-16T18:04:25.888Z INFO  [gw_bin::triggers::schedule] Starting schedule in every 1m.
+2024-10-16T18:04:25.906Z DEBUG [gw_bin::actions::process] [ping] PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
+2024-10-16T18:04:25.906Z DEBUG [gw_bin::actions::process] [ping] 64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=16.8 ms
+```
+
+Unlike scripts, you can only define one process and they are executed directly instead of in a shell. Processes also can't access gw-specific environment variables. 
+
+If a process fails, by default it marked failed and an error printed. If you want to retry the process you can set the `--process-retries` flag:
+
+```sh
+gw /path/to/repo -v -s 'ping 1.1.1.1' --process-retries 5
+```
+
+You can also change the stopping behaviour. By default processes are first tried to be gracefully stopped with SIGINT and after some timeout (default: 10s) they are killed. If you want to influence these values you can set `--stop-signal` and `--stop-timeout` respectively. On non-Unix systems these options do nothing and the process is always killed.
+
+```sh
+gw /path/to/repo -v -s 'ping 1.1.1.1' --stop-signal SIGTERM --stop-timeout 10s
+```
+
+Best use-cases for processes:
+
+- run [interpreted programs](/guides/interpreted) e.g. web frameworks,
+- run binaries after [compiling](/guides/compiled),
+- run external programs to restart [on config change](/guides/configuration).

--- a/docs/content/usage/crontab.md
+++ b/docs/content/usage/crontab.md
@@ -1,6 +1,6 @@
 +++
 title = "Crontab"
-weight = 5
+weight = 6
 +++
 
 # Crontab

--- a/docs/content/usage/docker.md
+++ b/docs/content/usage/docker.md
@@ -1,6 +1,6 @@
 +++
 title = "Docker container"
-weight = 4
+weight = 5
 +++
 
 # Docker container

--- a/docs/content/usage/docker.md
+++ b/docs/content/usage/docker.md
@@ -52,7 +52,7 @@ Most applications have many dependencies and complicated setups, and are already
 
 **NOTE**: This doesn't mean that these should be running in the same container, but they can use the same base image in two separate containers. It is a common wisdom that one container should run one thing.
 
-For this we can start off of our application image as a base layer and add the `gw` binary in a `COPY` layer:
+For this we can start off of our application image as a base layer and add the `gw` binary in a `COPY` layer. You can simply wrap your existing command using subprocess mode (`-p`) and it will restart the script every time a pull happened.
 
 ```dockerfile
 FROM example.org/registry/node-image:ubuntu
@@ -61,5 +61,5 @@ FROM example.org/registry/node-image:ubuntu
 COPY --from=danielgrant/gw:0.3.2 /usr/bin/gw /usr/bin/gw
 
 ENTRYPOINT ["/usr/bin/gw"]
-CMD ["/app", "-s", "npm run build"]
+CMD ["/app", "-p", "npm start"]
 ```

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -28,13 +28,13 @@ cd time
 To get started, point `gw` to this local repository. By default it pulls the changes every minute. We can add the `--verbose` or `-v` flag to see when the changes occur:
 
 ```sh
-gw . -v
+gw /path/to/repo -v
 ```
 
 If you are using your own repository, create a commit in a different place, and see how it gets automatically pulled (in the case of the `time` repo, there is a commit every minute). The verbose logs should print that a git pull happened:
 
 ```sh
-$ gw . -v
+$ gw /path/to/repo -v
 # ...
 2024-03-10T14:48:13.447Z DEBUG [gw_bin::checks::git::repository] Checked out fc23d21 on branch main.
 2024-03-10T14:48:13.447Z INFO  [gw_bin::start] There are updates, pulling.
@@ -52,21 +52,23 @@ git log -1  # it should be a commit in the last minute
 Pulling files automatically is useful but the `--script` or `-s` flag unlocks `gw`'s potential: it can run any kind of custom script if there are any changes. For a simple example, we can print the content of a file to the log with `cat`:
 
 ```sh
-gw . -v --script 'cat DATETIME'
+gw /path/to/repo -v --script 'cat DATETIME'
 ```
 
 This will run every time there is a new commit, and after the pull it will print the file contents. You can see that the results are printed in the log:
 
 ```sh
-$ gw . -v --script 'cat DATETIME'
+$ gw /path/to/repo -v --script 'cat DATETIME'
 # ...
 2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
-2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /home/grant/Development/quick/time.
+2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /path/to/repo.
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000
 ```
 
 You can add multiple scripts, which will run one after another. Use these scripts to build source files, restarts deployments and anything else that you can imagine.
+
+For more information, see [Scripts](/usage/actions#scripts).
 
 ### Run subprocess, restart on pull
 
@@ -75,14 +77,16 @@ It is often enough to run scripts, but many times you also want to maintain a lo
 For example starting a python web server:
 
 ```sh
-$ gw . -v --process "python -m http.server"
+$ gw /path/to/repo -v --process "python -m http.server"
 # ...
 2024-10-06T21:58:21.306Z DEBUG [gw] Setting up ProcessAction "python -m http.server" on change.
-2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /home/grant/Development/grant/gw.
+2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /path/to/repo.
 2024-10-06T21:58:56.211Z DEBUG [gw_bin::actions::process] [python] Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 ```
 
 This will run a python process in the background and stop and start it again if a git pull happened. Just wrap your deployment script with `gw` and see it gets updated every time you push to git.
+
+For more information, see [Processes](/usage/actions#processes).
 
 ## Next steps
 

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -68,6 +68,22 @@ $ gw . -v --script 'cat DATETIME'
 
 You can add multiple scripts, which will run one after another. Use these scripts to build source files, restarts deployments and anything else that you can imagine.
 
+### Run subprocess, restart on pull
+
+It is often enough to run scripts, but many times you also want to maintain a long-running process e.g. for web services. `gw` can help you with this, using the `-p` flag. This will start a process in the background and restart it on pull.
+
+For example starting a python web server:
+
+```sh
+$ gw . -v -p "python -m http.server"
+# ...
+2024-10-06T21:58:21.306Z DEBUG [gw] Setting up ProcessAction "python -m http.server" on change.
+2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /home/grant/Development/grant/gw.
+2024-10-06T21:58:56.211Z DEBUG [gw_bin::actions::process] [python] Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+```
+
+This will run a python process in the background and stop and start it again if a git pull happened. Just wrap your deployment script with `gw` and see it gets updated every time you push to git.
+
 ## Next steps
 
 If you like `gw`, there are multiple ways to use it for real-life use-cases.

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -60,7 +60,7 @@ This will run every time there is a new commit, and after the pull it will print
 ```sh
 $ gw . -v --script 'cat DATETIME'
 # ...
-2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running scripts.
+2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
 2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /home/grant/Development/quick/time.
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -70,12 +70,12 @@ You can add multiple scripts, which will run one after another. Use these script
 
 ### Run subprocess, restart on pull
 
-It is often enough to run scripts, but many times you also want to maintain a long-running process e.g. for web services. `gw` can help you with this, using the `-p` flag. This will start a process in the background and restart it on pull.
+It is often enough to run scripts, but many times you also want to maintain a long-running process e.g. for web services. `gw` can help you with this, using the `--process` or `-p` flag. This will start a process in the background and restart it on pull.
 
 For example starting a python web server:
 
 ```sh
-$ gw . -v -p "python -m http.server"
+$ gw . -v --process "python -m http.server"
 # ...
 2024-10-06T21:58:21.306Z DEBUG [gw] Setting up ProcessAction "python -m http.server" on change.
 2024-10-06T21:58:21.306Z DEBUG [gw_bin::actions::process] Starting process: "python" in directory /home/grant/Development/grant/gw.

--- a/docs/content/usage/systemd.md
+++ b/docs/content/usage/systemd.md
@@ -1,6 +1,6 @@
 +++
 title = "Systemd unit"
-weight = 3
+weight = 4
 +++
 
 # Systemd unit

--- a/docs/content/usage/webhook.md
+++ b/docs/content/usage/webhook.md
@@ -1,6 +1,6 @@
 +++
 title = "Webhook server"
-weight = 6
+weight = 7
 +++
 
 # Webhook server
@@ -12,7 +12,7 @@ By default `gw` checks for updates every minute. Depending on your usecase it ca
 To enable the webhook server, you can use the `--http` option. Most of the time you want to allow external connections, so to set to a high port (for example `10101`), you can use:
 
 ```sh
-gw . -v --http 0.0.0.0:10101
+gw /path/to/repo -v --http 0.0.0.0:10101
 ```
 
 If you call this endpoint with any method on any URL, it will trigger a check for updates. To test this, you can use `curl`:
@@ -24,7 +24,7 @@ curl http://localhost:10101
 The `curl` output should print `OK` and the `gw` logs should include lines that show that it was updated:
 
 ```sh
-$ gw . -v --http 0.0.0.0:10101
+$ gw /path/to/repo -v --http 0.0.0.0:10101
 # ...
 2024-03-10T16:52:51.531Z DEBUG [gw_bin::triggers::http] Received request on GET /
 2024-03-10T16:52:52.055Z DEBUG [gw_bin::checks::git::repository] Checked out 5e25714 on branch main.
@@ -34,7 +34,7 @@ $ gw . -v --http 0.0.0.0:10101
 If you want to disable the scheduled checks altogether and rely on the webhooks, you can set the schedule duration (`-d` flag) to zero seconds:
 
 ```sh
-gw . -v --http 0.0.0.0:10101 -d 0s
+gw /path/to/repo -v --http 0.0.0.0:10101 -d 0s
 ```
 
 ## Setup webhooks
@@ -58,7 +58,7 @@ On save, the webhook should send a `ping` event to `gw`. If you click into new w
 A `POST /` request will also appear in the `gw` logs, assuming debug logging was enabled:
 
 ```sh
-$ gw . -v --http 0.0.0.0:10101
+$ gw /path/to/repo -v --http 0.0.0.0:10101
 # ...
 2024-03-10T17:18:24.424Z DEBUG [gw_bin::triggers::http] Received request on POST /
 2024-03-10T17:18:24.567Z DEBUG [gw_bin::start] There are no updates.
@@ -73,7 +73,7 @@ For GitLab, you have to have Maintainer access to the repository. Navigate to **
 To test this webhook, you can click **Test > Push events** next to the name. GitLab should show a message that **Hook executed successfully: HTTP 200**, and you can find a `POST /` request in the `gw` logs, assuming debug logging was enabled:
 
 ```sh
-$ gw . -v --http 0.0.0.0:10101
+$ gw /path/to/repo -v --http 0.0.0.0:10101
 # ...
 2024-03-10T17:58:28.919Z DEBUG [gw_bin::triggers::http] Received request on POST /
 2024-03-10T17:58:29.052Z DEBUG [gw_bin::start] There are no updates.

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -6,6 +6,9 @@
         <title>gw - {{ section.title }}</title>
         <link rel="stylesheet" href="/sakura-dark.css" />
         <link rel="stylesheet" href="/custom.css" />
+        {% if config.base_url == "https://gw.danielgrants.com" %}
+        <script defer src="https://umami.danielgrants.com/script.js" data-website-id="178d68b6-42dc-4286-8a11-43bc183a397e"></script>
+        {% endif %}
     </head>
     <body>
         {% include "partials/toc.html" %}

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -6,6 +6,9 @@
         <title>gw - {{ page.title }}</title>
         <link rel="stylesheet" href="/sakura-dark.css" />
         <link rel="stylesheet" href="/custom.css" />
+        {% if config.base_url == "https://gw.danielgrants.com" %}
+        <script defer src="https://umami.danielgrants.com/script.js" data-website-id="178d68b6-42dc-4286-8a11-43bc183a397e"></script>
+        {% endif %}
     </head>
     <body>
         {% include "partials/toc.html" %}

--- a/docs/templates/section.html
+++ b/docs/templates/section.html
@@ -6,6 +6,9 @@
         <title>gw - {{ section.title }}</title>
         <link rel="stylesheet" href="/sakura-dark.css" />
         <link rel="stylesheet" href="/custom.css" />
+        {% if config.base_url == "https://gw.danielgrants.com" %}
+        <script defer src="https://umami.danielgrants.com/script.js" data-website-id="178d68b6-42dc-4286-8a11-43bc183a397e"></script>
+        {% endif %}
     </head>
     <body>
         {% include "partials/toc.html" %}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -29,5 +29,5 @@ pub enum ActionError {
 #[automock]
 pub trait Action {
     /// Initiate the action
-    fn run(&self, context: &Context) -> Result<(), ActionError>;
+    fn run(&mut self, context: &Context) -> Result<(), ActionError>;
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -2,6 +2,8 @@ use crate::context::Context;
 use mockall::automock;
 use thiserror::Error;
 
+/// An action to run in the background and restart a subprocess.
+pub mod process;
 /// An action to run a custom shell script.
 pub mod script;
 

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -1,0 +1,114 @@
+use super::{Action, ActionError};
+use crate::context::Context;
+use duct::Handle;
+use duct_sh::sh_dangerous;
+use log::{debug, error};
+use std::cell::RefCell;
+use thiserror::Error;
+
+const ACTION_NAME: &str = "PROCESS";
+
+/// An action to run in the background and restart a subprocess.
+pub struct ProcessAction {
+    directory: String,
+    command: String,
+    process: RefCell<Handle>,
+}
+
+/// Custom error describing the error cases for the ProcessAction.
+#[derive(Debug, Error)]
+pub enum ProcessError {
+    /// The underlying Rust command creation failed. The parameter contains the error.
+    #[error("the script cannot run: {0}")]
+    ProcessFailure(#[from] std::io::Error),
+}
+
+impl From<ProcessError> for ActionError {
+    fn from(value: ProcessError) -> Self {
+        ActionError::FailedAction(value.to_string())
+    }
+}
+
+impl ProcessAction {
+    /// Creates a new process on a new thread.
+    pub fn new(directory: String, command: String) -> Self {
+        let process = RefCell::new(
+            ProcessAction::start_process(&command, &directory).expect("Cannot start process."),
+        );
+
+        ProcessAction {
+            directory,
+            command,
+            process,
+        }
+    }
+
+    fn start_process(command: &str, directory: &str) -> Result<Handle, ProcessError> {
+        // We can run `sh_dangerous`, because it is on the user's computer.
+        let mut command = sh_dangerous(command);
+
+        // Set the environment variables
+        command = command.env("CI", "true");
+        command = command.env("GW_ACTION_NAME", ACTION_NAME);
+        command = command.env("GW_DIRECTORY", directory);
+
+        // Start the shell script
+        let handle = command
+            .stderr_to_stdout()
+            .stdout_capture()
+            .dir(directory)
+            .unchecked()
+            .start()?;
+
+        Ok(handle)
+    }
+
+    fn stop_process(&self) -> Result<(), ProcessError> {
+        self.process.borrow().kill()?;
+        Ok(())
+    }
+
+    fn run_inner(&self) -> Result<(), ProcessError> {
+        self.stop_process()?;
+        self.process.replace(ProcessAction::start_process(
+            &self.command,
+            &self.directory,
+        )?);
+
+        Ok(())
+    }
+}
+
+impl Action for ProcessAction {
+    /// Kills and restarts the subprocess.
+    fn run(&self, _context: &Context) -> Result<(), ActionError> {
+        debug!(
+            "Running script: {} in directory {}.",
+            self.command, self.directory
+        );
+
+        match self.run_inner() {
+            Ok(()) => {
+                debug!("Process restarted.");
+                Ok(())
+            }
+            Err(err) => {
+                error!("Failed: {err}.");
+                Err(err.into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_create_new_script() {
+        let action = ProcessAction::new(String::from("."), String::from("echo test"));
+
+        assert_eq!("echo test", action.command);
+        assert_eq!(".", action.directory);
+    }
+}

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -123,6 +123,11 @@ impl Process {
             params.args
         );
 
+        info!(
+            "Starting process {:?} in {}.",
+            params.command, params.directory,
+        );
+
         // Create child
         let child = duct::cmd(&params.command, &params.args)
             .dir(&params.directory)
@@ -134,15 +139,9 @@ impl Process {
             .reader()
             .map_err(|err| ProcessError::StartFailure(err.to_string()))?;
 
-        info!(
-            "Started process {:?} with id {}.",
-            params.command,
-            child
-                .pids()
-                .first()
-                .map(ToString::to_string)
-                .unwrap_or("unknown".to_string())
-        );
+        if let Some(pid) = child.pids().first() {
+            trace!("Started process with pid {pid}.",);
+        }
 
         Ok(child)
     }
@@ -320,10 +319,6 @@ pub struct ProcessAction {
 impl ProcessAction {
     /// Creates a new process in the background.
     pub fn new(params: ProcessParams) -> Result<ProcessAction, ProcessError> {
-        debug!(
-            "Starting process: {:?} in directory {}.",
-            params.command, params.directory
-        );
         let process = Process::start(&params)?;
 
         Ok(ProcessAction { params, process })

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -1,7 +1,7 @@
 use super::{Action, ActionError};
 use crate::context::Context;
 use duct::ReaderHandle;
-use log::{debug, error, trace};
+use log::{debug, error, info, trace, warn};
 use nix::{errno::Errno, sys::signal::Signal};
 use std::{
     io::{BufRead, BufReader},
@@ -118,7 +118,7 @@ pub struct Process {
 impl Process {
     fn start_child(params: &ProcessParams) -> Result<ReaderHandle, ProcessError> {
         trace!(
-            "Running command {:?} with args: {:?}.",
+            "Running process {:?} with args: {:?}.",
             params.command,
             params.args
         );
@@ -134,8 +134,8 @@ impl Process {
             .reader()
             .map_err(|err| ProcessError::StartFailure(err.to_string()))?;
 
-        trace!(
-            "Started command {:?} with id {}.",
+        info!(
+            "Started process {:?} with id {}.",
             params.command,
             child
                 .pids()
@@ -182,7 +182,7 @@ impl Process {
                     break;
                 }
 
-                debug!(
+                warn!(
                     "Process {:?} failed, retrying ({} retries left).",
                     thread_params.command, tries
                 );
@@ -265,7 +265,7 @@ impl Process {
             while start_time.elapsed() < self.stop_timeout {
                 trace!("Testing process state.");
                 if let Ok(Some(output)) = child.try_wait() {
-                    debug!("Process stopped gracefully with status {}.", output.status);
+                    info!("Process stopped gracefully with status {}.", output.status);
                     return Ok(());
                 }
                 sleep(Duration::from_secs(1));
@@ -280,7 +280,7 @@ impl Process {
                 .kill()
                 .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
 
-            debug!("Process killed successfully.");
+            info!("Process killed successfully.");
         } else {
             debug!("Cannot restart process, because it has already failed.");
         }
@@ -301,7 +301,7 @@ impl Process {
                 .kill()
                 .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
 
-            debug!("Process stopped successfully.");
+            info!("Process stopped successfully.");
         } else {
             debug!("Cannot restart process, because it has already failed.");
         }

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -14,7 +14,7 @@ const ACTION_NAME: &str = "PROCESS";
 
 /// Parameters for the process.
 #[derive(Debug)]
-#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+#[cfg_attr(unix, allow(dead_code))]
 pub struct ProcessParams {
     pub directory: String,
     pub command: String,
@@ -25,7 +25,7 @@ pub struct ProcessParams {
 
 /// Struct that can handle the lifecycle of the process with restarting etc.
 #[derive(Debug)]
-#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+#[cfg_attr(unix, allow(dead_code))]
 pub struct Process {
     child: Child,
     stop_signal: String,
@@ -75,7 +75,7 @@ impl Process {
         })
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     fn stop(&mut self) -> Result<(), ProcessError> {
         use duration_string::DurationString;
         use log::trace;
@@ -114,7 +114,7 @@ impl Process {
         Ok(())
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(not(unix))]
     fn stop(&mut self) -> Result<(), ProcessError> {
         self.handle
             .kill()

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -4,16 +4,41 @@ use log::{debug, error, trace};
 use std::{
     collections::HashMap,
     io::{BufRead, BufReader},
+    ops::DerefMut,
     process::{Child, Command, Stdio},
-    thread,
+    sync::{
+        mpsc::{channel, Sender},
+        Arc, Mutex,
+    },
+    thread::{self, sleep},
     time::Duration,
 };
 use thiserror::Error;
 
 const ACTION_NAME: &str = "PROCESS";
 
+/// Custom error describing the error cases for the ProcessAction.
+#[derive(Debug, Error)]
+pub enum ProcessError {
+    /// The underlying Rust command creation failed. The parameter contains the error.
+    #[error("the command {0} cannot be parsed")]
+    CommandParseFailure(String),
+    /// The underlying Rust command creation failed. The parameter contains the error.
+    #[error("the script cannot start: {0}")]
+    StartFailure(String),
+    /// Killing the command failed.
+    #[error("the script cannot be stopped: {0}")]
+    StopFailure(String),
+}
+
+impl From<ProcessError> for ActionError {
+    fn from(value: ProcessError) -> Self {
+        ActionError::FailedAction(value.to_string())
+    }
+}
+
 /// Parameters for the process.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(unix, allow(dead_code))]
 pub struct ProcessParams {
     pub directory: String,
@@ -30,10 +55,11 @@ pub struct Process {
     child: Child,
     stop_signal: String,
     stop_timeout: Duration,
+    retries: u32,
 }
 
 impl Process {
-    fn start(params: &ProcessParams) -> Result<Process, ProcessError> {
+    fn start(params: &ProcessParams, tx: Sender<u32>) -> Result<Process, ProcessError> {
         let split_args = shlex::split(&params.command)
             .ok_or(ProcessError::StopFailure(params.command.clone()))?;
 
@@ -61,17 +87,21 @@ impl Process {
             .map_err(|err| ProcessError::StartFailure(err.to_string()))?;
 
         let stdout = child.stdout.take().unwrap();
+        let command_id = command.clone();
+        let retries = params.retries;
         thread::spawn(move || {
             let mut reader = BufReader::new(stdout).lines();
             while let Some(Ok(line)) = reader.next() {
-                debug!("  {line}");
+                debug!("[{command_id}] {line}");
             }
+            tx.send(retries).unwrap();
         });
 
         Ok(Process {
             child,
             stop_signal: params.stop_signal.clone(),
             stop_timeout: params.stop_timeout,
+            retries,
         })
     }
 
@@ -129,28 +159,9 @@ impl Process {
 /// An action to run in the background and restart a subprocess.
 #[derive(Debug)]
 pub struct ProcessAction {
+    tx: Sender<u32>,
     params: ProcessParams,
-    process: Process,
-}
-
-/// Custom error describing the error cases for the ProcessAction.
-#[derive(Debug, Error)]
-pub enum ProcessError {
-    /// The underlying Rust command creation failed. The parameter contains the error.
-    #[error("the command {0} cannot be parsed")]
-    CommandParseFailure(String),
-    /// The underlying Rust command creation failed. The parameter contains the error.
-    #[error("the script cannot start: {0}")]
-    StartFailure(String),
-    /// Killing the command failed.
-    #[error("the script cannot be stopped: {0}")]
-    StopFailure(String),
-}
-
-impl From<ProcessError> for ActionError {
-    fn from(value: ProcessError) -> Self {
-        ActionError::FailedAction(value.to_string())
-    }
+    process: Arc<Mutex<Option<Process>>>,
 }
 
 impl ProcessAction {
@@ -160,17 +171,55 @@ impl ProcessAction {
             "Starting process: {} in directory {}.",
             params.command, params.directory
         );
-        let process = Process::start(&params).expect("Cannot start process.");
+        let (tx, rx) = channel();
+        let process = Arc::new(Mutex::new(Some(
+            Process::start(&params, tx.clone()).expect("Cannot start process."),
+        )));
 
-        ProcessAction { params, process }
+        let process_action = ProcessAction {
+            params: params.clone(),
+            process: process.clone(),
+            tx: tx.clone(),
+        };
+
+        let max_retries = params.retries;
+        thread::spawn(move || {
+            for previous_retries in rx {
+                let mut process_container = process.lock().unwrap();
+                let mut new_params = params.clone();
+                new_params.retries = previous_retries - 1;
+                if new_params.retries > 0 {
+                    debug!(
+                        "Process {} failed, retrying ({} retries left).",
+                        params.command, new_params.retries
+                    );
+                    sleep(Duration::from_millis(100));
+                    process_container.replace(Process::start(&new_params, tx.clone()).unwrap());
+                } else {
+                    error!(
+                        "Process {} failed more than {} times, we are not retrying anymore.",
+                        params.command, max_retries,
+                    );
+                    process_container.take();
+                }
+            }
+        });
+
+        process_action
     }
 
     fn run_inner(&mut self) -> Result<(), ProcessError> {
-        debug!("Restarting process.");
-        self.process
-            .stop()
-            .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
-        self.process = Process::start(&self.params)?;
+        let mut process_container = self.process.lock().unwrap();
+        if let Some(process) = process_container.deref_mut() {
+            debug!("Restarting process.");
+            process
+                .stop()
+                .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
+        } else {
+            debug!("Cannot restart process, because it has already failed.");
+        }
+
+        process_container.replace(Process::start(&self.params, self.tx.clone())?);
 
         Ok(())
     }
@@ -195,7 +244,8 @@ impl Action for ProcessAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Instant;
+    use std::{fs, time::Instant};
+    use thread::sleep;
 
     #[test]
     fn it_should_start_a_new_process() {
@@ -206,8 +256,15 @@ mod tests {
             stop_signal: String::from("SIGTERM"),
             stop_timeout: Duration::from_secs(5),
         };
-        let mut action = ProcessAction::new(params);
-        action.process.stop().unwrap();
+        let action = ProcessAction::new(params);
+        action
+            .process
+            .lock()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .stop()
+            .unwrap();
 
         assert_eq!("sleep 100", action.params.command);
         assert_eq!(".", action.params.directory);
@@ -226,10 +283,10 @@ mod tests {
         let mut action = ProcessAction::new(params);
 
         let initial_time = Instant::now();
-        let first_pid = action.process.child.id();
+        let first_pid = action.process.lock().unwrap().as_ref().unwrap().child.id();
         action.run_inner()?;
-        let second_pid = action.process.child.id();
-        action.process.stop()?;
+        let second_pid = action.process.lock().unwrap().as_ref().unwrap().child.id();
+        action.process.lock().unwrap().as_mut().unwrap().stop()?;
 
         assert_ne!(
             first_pid, second_pid,
@@ -239,6 +296,58 @@ mod tests {
             initial_time.elapsed() <= stop_timeout,
             "The stop timeout should not be elapsed."
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_should_retry_the_process_if_it_exits_until_the_retry_count() -> Result<(), ProcessError> {
+        let stop_timeout = Duration::from_secs(5);
+        let params = ProcessParams {
+            command: String::from("echo 1"),
+            directory: String::from("."),
+            retries: 5,
+            stop_signal: String::from("SIGTERM"),
+            stop_timeout,
+        };
+        let action = ProcessAction::new(params);
+
+        sleep(Duration::from_secs(1));
+
+        let is_process_exited = action.process.lock().unwrap().as_ref().is_none();
+
+        assert!(is_process_exited, "The process should exit.");
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_should_reset_the_retries() -> Result<(), ProcessError> {
+        let tailed_file = "./test_directories/tailed_file";
+        let stop_timeout = Duration::from_secs(5);
+        let params = ProcessParams {
+            command: format!("tail -f {tailed_file}"),
+            directory: String::from("."),
+            retries: 5,
+            stop_signal: String::from("SIGTERM"),
+            stop_timeout,
+        };
+
+        // First time it should fail, because the file doesn't exist yet
+        let mut action = ProcessAction::new(params);
+
+        // Create the file and restart it quickly to see the retries reset
+        fs::write(tailed_file, "").unwrap();
+        action.run_inner()?;
+
+        let is_process_running = action.process.lock().unwrap().as_ref().is_some();
+        assert!(is_process_running, "The process should be running.");
+
+        let retries = action.process.lock().unwrap().as_ref().unwrap().retries;
+        assert_eq!(retries, 5);
+
+        action.process.lock().unwrap().as_mut().unwrap().stop()?;
+        fs::remove_file(tailed_file).unwrap();
 
         Ok(())
     }

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -5,19 +5,78 @@ use duct_sh::sh_dangerous;
 use log::{debug, error};
 use std::{
     io::{BufRead, BufReader},
-    ops::Deref,
     sync::Arc,
     thread,
+    time::Duration,
 };
 use thiserror::Error;
 
 const ACTION_NAME: &str = "PROCESS";
 
+/// Parameters for the process.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ProcessParams {
+    pub directory: String,
+    pub command: String,
+    pub retries: u32,
+    pub stop_signal: String,
+    pub stop_timeout: Duration,
+}
+
+/// Struct that can handle the lifecycle of the process with restarting etc.
+#[derive(Debug)]
+pub struct Process {
+    handle: ReaderHandle,
+}
+
+impl Process {
+    fn start(params: &ProcessParams) -> Result<Arc<Process>, ProcessError> {
+        // We can run `sh_dangerous`, because it is on the user's computer.
+        let mut command = sh_dangerous(&params.command);
+
+        // Set the environment variables
+        command = command.env("CI", "true");
+        command = command.env("GW_ACTION_NAME", ACTION_NAME);
+        command = command.env("GW_DIRECTORY", &params.directory);
+
+        // Start the shell script
+        let handle = command
+            .stderr_to_stdout()
+            .stdout_capture()
+            .dir(&params.directory)
+            .reader()
+            .map_err(|err| ProcessError::StartFailure(err.to_string()))?;
+
+        let process = Arc::new(Process {
+            handle,
+        });
+        let thread_process = process.clone();
+        thread::spawn(move || {
+            let thread_handle = &thread_process.handle;
+            let mut reader = BufReader::new(thread_handle).lines();
+            while let Some(Ok(line)) = reader.next() {
+                debug!("  {line}");
+            }
+        });
+
+        Ok(process)
+    }
+
+    fn stop(&self) -> Result<(), ProcessError> {
+        self.handle
+            .kill()
+            .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
+
+        Ok(())
+    }
+}
+
 /// An action to run in the background and restart a subprocess.
+#[derive(Debug)]
 pub struct ProcessAction {
-    directory: String,
-    command: String,
-    process: Arc<ReaderHandle>,
+    params: ProcessParams,
+    process: Arc<Process>,
 }
 
 /// Custom error describing the error cases for the ProcessAction.
@@ -39,60 +98,22 @@ impl From<ProcessError> for ActionError {
 
 impl ProcessAction {
     /// Creates a new process in the background.
-    pub fn new(directory: String, command: String) -> Self {
-        let process =
-            ProcessAction::start_process(&command, &directory).expect("Cannot start process.");
+    pub fn new(params: ProcessParams) -> Self {
+        debug!(
+            "Starting process: {} in directory {}.",
+            params.command, params.directory
+        );
+        let process = Process::start(&params).expect("Cannot start process.");
 
-        ProcessAction {
-            directory,
-            command,
-            process,
-        }
-    }
-
-    fn start_process(command: &str, directory: &str) -> Result<Arc<ReaderHandle>, ProcessError> {
-        debug!("Starting process: {command} in directory {directory}.",);
-
-        // We can run `sh_dangerous`, because it is on the user's computer.
-        let mut command = sh_dangerous(command);
-
-        // Set the environment variables
-        command = command.env("CI", "true");
-        command = command.env("GW_ACTION_NAME", ACTION_NAME);
-        command = command.env("GW_DIRECTORY", directory);
-
-        // Start the shell script
-        let handle = command
-            .stderr_to_stdout()
-            .stdout_capture()
-            .dir(directory)
-            .reader()
-            .map_err(|err| ProcessError::StartFailure(err.to_string()))?;
-
-        let return_handle = Arc::new(handle);
-        let thread_handle = return_handle.clone();
-        thread::spawn(move || {
-            let mut reader = BufReader::new(thread_handle.deref()).lines();
-            while let Some(Ok(line)) = reader.next() {
-                debug!("  {line}");
-            }
-        });
-
-        Ok(return_handle)
-    }
-
-    fn stop_process(&self) -> Result<(), ProcessError> {
-        debug!("Stopping process to restart.");
-        self.process
-            .kill()
-            .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
-
-        Ok(())
+        ProcessAction { params, process }
     }
 
     fn run_inner(&mut self) -> Result<(), ProcessError> {
-        self.stop_process()?;
-        self.process = ProcessAction::start_process(&self.command, &self.directory)?;
+        debug!("Restarting process.");
+        self.process
+            .stop()
+            .map_err(|err| ProcessError::StopFailure(err.to_string()))?;
+        self.process = Process::start(&self.params)?;
 
         Ok(())
     }
@@ -120,19 +141,33 @@ mod tests {
 
     #[test]
     fn it_should_start_a_new_process() {
-        let action = ProcessAction::new(String::from("."), String::from("sleep 100"));
+        let params = ProcessParams {
+            command: String::from("sleep 100"),
+            directory: String::from("."),
+            retries: 5,
+            stop_signal: String::from("SIGINT"),
+            stop_timeout: Duration::from_secs(5),
+        };
+        let action = ProcessAction::new(params);
 
-        assert_eq!("sleep 100", action.command);
-        assert_eq!(".", action.directory);
+        assert_eq!("sleep 100", action.params.command);
+        assert_eq!(".", action.params.directory);
     }
 
     #[test]
     fn it_should_restart_the_process_with_run_inner() -> Result<(), ProcessError> {
-        let mut action = ProcessAction::new(String::from("."), String::from("sleep 100"));
+        let params = ProcessParams {
+            command: String::from("sleep 100"),
+            directory: String::from("."),
+            retries: 5,
+            stop_signal: String::from("SIGINT"),
+            stop_timeout: Duration::from_secs(5),
+        };
+        let mut action = ProcessAction::new(params);
 
-        let first_pids = action.process.pids();
+        let first_pids = action.process.handle.pids();
         action.run_inner()?;
-        let second_pids = action.process.pids();
+        let second_pids = action.process.handle.pids();
 
         assert_ne!(
             first_pids, second_pids,

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -87,7 +87,7 @@ impl Action for ScriptAction {
     /// Run the script in a subshell (`/bin/sh` on *nix, `cmd.exe` on Windows).
     /// If the script fails to start, return a non-zero error code or prints non-utf8
     /// characters, this function will result in an error.
-    fn run(&self, context: &Context) -> Result<(), ActionError> {
+    fn run(&mut self, context: &Context) -> Result<(), ActionError> {
         debug!(
             "Running script: {} in directory {}.",
             self.command, self.directory

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -1,7 +1,7 @@
 use super::{Action, ActionError};
 use crate::context::Context;
 use duct_sh::sh_dangerous;
-use log::{debug, error};
+use log::{debug, error, info};
 use thiserror::Error;
 
 const ACTION_NAME: &str = "SCRIPT";
@@ -95,9 +95,9 @@ impl Action for ScriptAction {
 
         match self.run_inner(context) {
             Ok(result) => {
-                debug!("Command success, output:");
+                info!("Script {:?} finished successfully.", self.command);
                 result.lines().for_each(|line| {
-                    debug!("  {line}");
+                    debug!("[{}]  {line}", self.command);
                 });
                 Ok(())
             }

--- a/src/args.rs
+++ b/src/args.rs
@@ -69,6 +69,18 @@ pub struct Args {
     #[options(no_short)]
     pub http: Option<String>,
 
+    /// The number of times to retry the background process in case it fails. By default 0 for no retries.
+    #[options(no_short, meta = "N")]
+    pub process_retries: Option<u32>,
+
+    /// The stop signal to give the background process. Useful for graceful shutdowns. By default SIGINT. (Only supported on *NIX)
+    #[options(no_short, meta = "SIGNAL")]
+    pub stop_signal: Option<String>,
+
+    /// The timeout to wait before killing for the background process to shutdown gracefully. By default 10s.
+    #[options(no_short, meta = "TIMEOUT")]
+    pub stop_timeout: Option<DurationString>,
+
     /// Increase verbosity, can be set multiple times (-v debug, -vv tracing).
     #[options(count)]
     pub verbose: u8,

--- a/src/args.rs
+++ b/src/args.rs
@@ -31,6 +31,10 @@ pub struct Args {
     #[options(long = "script")]
     pub scripts: Vec<String>,
 
+    /// A background process that will be restarted on change.
+    #[options()]
+    pub process: Option<String>,
+
     /// Try to pull only once. Useful for cronjobs.
     #[options(long = "once", no_short)]
     pub once: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ```
 //!
 
-/// An action is a process that runs if any changes occured (e.g. [running scripts](actions::script::ScriptAction)).
+/// An action is a process that runs if any changes occured (e.g. [running actions](actions::script::ScriptAction)).
 pub mod actions;
 /// A check is a process that tests if there are any changes and updates it.
 pub mod checks;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main_inner() -> Result<(), MainError> {
     }
 
     // Start the main script.
-    start(triggers, &mut check, &actions)?;
+    start(triggers, &mut check, &mut actions)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,19 @@ fn main_inner() -> Result<(), MainError> {
     }
     if let Some(process) = args.process {
         debug!("Setting up ProcessAction {process:?} on change.");
-        let process_params =
+        let mut process_params =
             ProcessParams::new(process, directory.clone()).map_err(ActionError::from)?;
 
+        if let Some(retries) = args.process_retries {
+            process_params.set_retries(retries);
+        }
+        if let Some(stop_signal) = args.stop_signal {
+            process_params.set_stop_signal(stop_signal).map_err(ActionError::from)?;
+        }
+        if let Some(stop_timeout) = args.stop_timeout {
+            process_params.set_stop_timeout(stop_timeout.into());
+        }
+ 
         actions.push(Box::new(
             ProcessAction::new(process_params).map_err(ActionError::from)?,
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 use args::parse_args;
 use gw_bin::{
-    actions::{process::ProcessAction, script::ScriptAction, Action},
+    actions::{
+        process::{ProcessAction, ProcessParams},
+        script::ScriptAction,
+        Action,
+    },
     checks::{
         git::{CredentialAuth, GitCheck},
         Check, CheckError,
@@ -95,7 +99,14 @@ fn main_inner() -> Result<(), MainError> {
     }
     if let Some(process) = args.process {
         debug!("Setting up ProcessAction '{process}' on change.");
-        actions.push(Box::new(ProcessAction::new(directory.clone(), process)));
+        let process_params = ProcessParams {
+            command: process,
+            directory: directory.clone(),
+            retries: 5,
+            stop_signal: String::from("SIGINT"),
+            stop_timeout: Duration::from_secs(5),
+        };
+        actions.push(Box::new(ProcessAction::new(process_params)));
     }
 
     if actions.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use args::parse_args;
 use gw_bin::{
-    actions::{script::ScriptAction, Action},
+    actions::{process::ProcessAction, script::ScriptAction, Action},
     checks::{
         git::{CredentialAuth, GitCheck},
         Check, CheckError,
@@ -92,6 +92,10 @@ fn main_inner() -> Result<(), MainError> {
     for script in args.scripts {
         debug!("Setting up ScriptAction '{script}' on change.");
         actions.push(Box::new(ScriptAction::new(directory.clone(), script)));
+    }
+    if let Some(process) = args.process {
+        debug!("Setting up ProcessAction '{process}' on change.");
+        actions.push(Box::new(ProcessAction::new(directory.clone(), process)));
     }
 
     if actions.is_empty() {

--- a/src/start.rs
+++ b/src/start.rs
@@ -50,7 +50,7 @@ pub fn start(
                     if actions.is_empty() {
                         "pulling"
                     } else {
-                        "running scripts"
+                        "running actions"
                     }
                 );
                 for action in actions.iter_mut() {

--- a/src/start.rs
+++ b/src/start.rs
@@ -23,7 +23,7 @@ pub enum StartError {
 pub fn start(
     triggers: Vec<Box<dyn Trigger>>,
     check: &mut Box<dyn Check>,
-    actions: &[Box<dyn Action>],
+    actions: &mut [Box<dyn Action>],
 ) -> Result<(), StartError> {
     let (tx, rx) = mpsc::channel::<Option<Context>>();
 
@@ -53,7 +53,7 @@ pub fn start(
                         "running scripts"
                     }
                 );
-                for action in actions {
+                for action in actions.iter_mut() {
                     let _ = action.run(&context);
                 }
             }
@@ -100,7 +100,7 @@ mod tests {
         // Setup mock action.
         let mut mock_action = MockAction::new();
         mock_action.expect_run().times(1).returning(|_| Ok(()));
-        let actions: &[Box<dyn Action>] = &[Box::new(mock_action)];
+        let actions: &mut [Box<dyn Action>] = &mut [Box::new(mock_action)];
 
         let result = start(triggers, &mut check, actions);
         assert!(result.is_ok());
@@ -125,7 +125,7 @@ mod tests {
         // Setup mock action.
         let mut mock_action = MockAction::new();
         mock_action.expect_run().times(0);
-        let actions: &[Box<dyn Action>] = &[Box::new(mock_action)];
+        let actions: &mut [Box<dyn Action>] = &mut [Box::new(mock_action)];
 
         let result = start(triggers, &mut check, actions);
         assert!(result.is_ok());
@@ -153,7 +153,7 @@ mod tests {
         // Setup mock action.
         let mut mock_action = MockAction::new();
         mock_action.expect_run().times(0);
-        let actions: &[Box<dyn Action>] = &[Box::new(mock_action)];
+        let actions: &mut [Box<dyn Action>] = &mut [Box::new(mock_action)];
 
         let result = start(triggers, &mut check, actions);
         assert!(result.is_ok());
@@ -172,7 +172,7 @@ mod tests {
         // Setup mock action.
         let mut mock_action = MockAction::new();
         mock_action.expect_run().times(0);
-        let actions: &[Box<dyn Action>] = &[Box::new(mock_action)];
+        let actions: &mut [Box<dyn Action>] = &mut [Box::new(mock_action)];
 
         let result = start(triggers, &mut check, actions);
         assert!(result.is_err());


### PR DESCRIPTION
- Refactor Command into duct cmd
- Setup process parameters
- Move configuration errors to the start to fail main
- Refactor error handling to avoid unwrapping
- Move Arc Mutex to the Process level
- Initial implementation for restarting
- Refactor cfg attributes
- Keep only the working tests
- Refactor code to use shlex instead of duct sh
- Add graceful stopping using nix
- Refactor code to separate lifecycle of process
- Add mutable actions
- Make all Action runs mutable
- Refactor process to log the outputs
- Add initial commit for process
