### PR TITLE
Move from simple_logger to simplelog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,16 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
-name = "colored"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
-dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,8 +202,9 @@ dependencies = [
  "rand",
  "shlex",
  "signal-hook",
- "simple_logger",
+ "simplelog",
  "thiserror",
+ "time",
  "tiny_http",
  "ureq",
 ]
@@ -248,12 +239,6 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -588,15 +573,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_logger"
-version = "5.0.0"
+name = "simplelog"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
 dependencies = [
- "colored",
  "log",
+ "termcolor",
  "time",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -619,6 +603,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -762,6 +755,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ mockall = "0.13.0"
 nix = { version = "0.29.0", features = ["signal"] }
 shlex = "1.3.0"
 signal-hook = "0.3.17"
-simple_logger = "5.0.0"
+simplelog = "0.12.2"
 thiserror = "1.0.56"
+time = "0.3.36"
 tiny_http = "0.12.0"
 
 [target.'cfg(any(target_env = "musl", target_arch = "arm", target_arch = "aarch64"))'.dependencies]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,39 @@
+use crate::{args::Args, MainError};
+use log::{warn, Level, LevelFilter};
+use simplelog::{
+    format_description, Color, ColorChoice, ConfigBuilder, LevelPadding, TermLogger, TerminalMode,
+};
+
+// Use the same format as simple_logger
+const TIMESTAMP_FORMAT_OFFSET: &[simplelog::FormatItem<'_>] = format_description!(
+    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3][offset_hour sign:mandatory]:[offset_minute]"
+);
+
+pub fn init_logger(args: &Args) -> Result<(), MainError> {
+    TermLogger::init(
+        match (args.quiet, args.verbose) {
+            (true, _) => LevelFilter::Error,
+            (false, 0) => LevelFilter::Info,
+            (false, 1) => LevelFilter::Debug,
+            (false, _) => LevelFilter::Trace,
+        },
+        ConfigBuilder::new()
+            .set_level_color(Level::Debug, Some(Color::Magenta))
+            .set_level_color(Level::Trace, None)
+            .set_level_padding(LevelPadding::Right)
+            .set_target_level(LevelFilter::Off)
+            .set_thread_level(LevelFilter::Off)
+            .set_time_format_custom(TIMESTAMP_FORMAT_OFFSET)
+            .set_time_offset_to_local()
+            .map_err(|_| MainError::FailedLoggerTimezones)?
+            .build(),
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    )?;
+
+    if args.verbose > 3 {
+        warn!("Okay, it's time to stop. It won't get more verbose than this.")
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
**Motivation**: `simple_logger` is a great library but it adds the module name to the output that is completely useless for an average user. `simplelog` is a more configurable solution, add this to remove the module name from the output and line up the process output with the outputs.

- Change logger to simplelog
