### PR TITLE
Make direct execute the default, add shell running flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Only change gitconfig (safe.directory) if there isn't one
 - Don't overwrite script environment, use already set variables
+- The order of script and process flags now matter, scripts are run before and after the process
 
 ## [0.3.2] - 2024-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
   - Use `-p` to start a process directly and restart on change
   - Configure the retries to restart the process in case of a failure
   - Set the stop signal and stop timeout args to configure graceful shutdown before restart
+  - Add `-P` to start the process in the shell instead
+- The order of script and process flags now matter, scripts are run in order before and after the process
 
 ### Changed
 
+- **Breaking change**: Scripts are now running directly, you can run it in a shell using `-S`
 - Only change gitconfig (safe.directory) if there isn't one
 - Don't overwrite script environment, use already set variables
-- The order of script and process flags now matter, scripts are run before and after the process
 
 ## [0.3.2] - 2024-08-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "shlex",
  "signal-hook",
  "simple_logger",
+ "testing_logger",
  "thiserror",
  "tiny_http",
  "ureq",
@@ -626,6 +627,15 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "testing_logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ git2 = { version = "0.19.0", features = ["vendored-libgit2", "vendored-openssl"]
 [dev-dependencies]
 duct = "0.13.7"
 rand = "0.8.5"
+testing_logger = "0.1.1"
 ureq = { version = "2.9.1", default-features = false }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ This will run every time there is a new commit, and after the pull it will print
 ```sh
 $ gw /path/to/repo -v --script 'cat DATETIME'
 # ...
-2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
-2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /path/to/repo.
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000
+2024-10-18T16:28:53.907Z INFO  [gw_bin::start] There are updates, running actions.
+2024-10-18T16:28:53.907Z INFO  [gw_bin::actions::script] Running script "cat" in /path/to/repo.
+2024-10-18T16:28:53.913Z DEBUG [gw_bin::actions::script] [cat] 2024-10-18T16:28:00+0000
+2024-10-18T16:28:53.913Z INFO  [gw_bin::actions::script] Script "cat" finished successfully.
 ```
 
 You can add multiple scripts, which will run one after another. Use these scripts to build source files, restarts deployments and anything else that you can imagine.
@@ -117,8 +117,9 @@ If you want to put the `gw` script in the background, you can:
 If you are interested in some ideas on how to use `gw`:
 
 - if you only need to pull files, see [PHP guide](https://gw.danielgrants.com/guides/php);
-- if you are using a compiled language, see [Guide for compiled languages](https://gw.danielgrants.com/guides/compiled) for example on restarting a process;
-- if you want to use `gw` with a `docker-compose.yaml`, see [Guide for docker-compose](guides/docker-compose);
+- if you are using a dynamic language (e.g. JavaScript, Python, Ruby), see [Guide for dynamic languages](https://gw.danielgrants.com/guides/dynamic) for example on running your process;
+- if you are using a compiled language (e.g. TypeScript, Go, Rust), see [Guide for compiled languages](https://gw.danielgrants.com/guides/compiled) for example on compiling your program;
+- if you use a `docker-compose.yaml`, see [Guide for docker-compose](guides/docker-compose);
 - if you want to easily manage configuration files as GitOps, see [Configuration guide](https://gw.danielgrants.com/guides/configuration);
 - for a full-blown example, check out [Netlify](https://gw.danielgrants.com/guides/netlify);
 - and many other things, for the incomplete list [guides page](https://gw.danielgrants.com/guides).

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -32,10 +32,10 @@ For more installation methods, see [Installation](/usage/installation).
 
 ## Get started
 
-To use `gw`, you have to point it to your local repository and it will pull changes automatically. You can run scripts on every pull to build or restart your deployments with the `--script` flag.
+To use `gw`, you have to point it to your local repository and it will pull changes automatically. You can run scripts on every pull to build with the `--script` (or `-s`) flag or run your deployments with the `--process` (or `-p`) flag.
 
 ```sh
-gw /path/to/repo --script 'run build process' --script 'restart deployment'
+gw /path/to/repo --script 'run build process' --process 'run deployment'
 ```
 
 For your first steps with `gw`, see [Get started](/usage/start).

--- a/docs/content/guides/compiled.md
+++ b/docs/content/guides/compiled.md
@@ -19,6 +19,12 @@ For example for TypeScript, transpile to JS and run with Node.js:
 gw /path/to/repo -s 'npx tsc -p tsconfig.json' -p 'node dist/index.js'
 ```
 
+If you want to ensure that your code is correct, you can run the unit tests first:
+
+```sh
+gw /path/to/repo  -s 'npm run test' -s 'npx tsc -p tsconfig.json' -p 'node dist/index.js'
+```
+
 For Next.js and other frameworks that require a build step before starting, you can use:
 
 ```sh
@@ -31,8 +37,14 @@ For Go, you can either run it directly or build it first and run it as a subproc
 
 ```sh
 gw /path/to/repo -p 'go run main.go'
-# or 
+# or
 gw /path/to/repo -s 'go build main.go' -p './main'
+```
+
+You can add testing as a script, if you want to run the unit tests before the code is deployed:
+
+```sh
+gw /path/to/repo -s 'go test' -s 'go build main.go' -p './main'
 ```
 
 ### Rust
@@ -41,8 +53,14 @@ For Rust, you can either run it directly or build it first and run it as a subpr
 
 ```sh
 gw /path/to/repo -p 'cargo run --release'
-# or 
+# or
 gw /path/to/repo -s 'cargo build --release' -p './target/release/repo'
+```
+
+Add the tests here as well to make sure that the code is correct:
+
+```sh
+gw /path/to/repo -s 'cargo test' -s 'cargo build --release' -p './target/release/repo'
 ```
 
 Also checkout [Docker configuration](/guides/docker-compose).

--- a/docs/content/guides/development.md
+++ b/docs/content/guides/development.md
@@ -7,7 +7,7 @@ weight = 6
 
 You can use `gw` to help in local development. You can pull your repository continuously, so in case somebody commits (and there is no conflicts) you can get the newest version. You can also set a notification to see immediately if somebody modified anything.
 
-> I don't recommend working on the same branch with multiple people, but sometimes it happens.
+> **Note**: I don't recommend working on the same branch with multiple people, but sometimes it happens.
 
 ## Configuration
 

--- a/docs/content/guides/docker-compose.md
+++ b/docs/content/guides/docker-compose.md
@@ -11,7 +11,7 @@ weight = 4
 
 Make sure to have a `docker-compose.yaml` file in the root directory. It can start existing containers or build images from the local files. 
 
-> Note: if you build docker images locally, you save the storage and transfer costs of the docker image repository.
+> **Note**: if you build docker images locally, you save the storage and transfer costs of the docker image repository.
 
 Since it is also a file in your git repository, it basically doubles as an infrastructure-as-a-code. You can modify the `docker compose` setup (e.g. add another dependency, for example cache), commit and have the changes reflected in your infrastructure immediately.
 

--- a/docs/content/guides/dynamic.md
+++ b/docs/content/guides/dynamic.md
@@ -19,7 +19,13 @@ For example for Node.js programs, use the usual `npm run start` script with a pr
 gw /path/to/repo -p 'npm run start'
 ```
 
-If you want to use a build step, for example for TypeScript look at the [TypeScript guide](/guides/compiled#typescript).
+You can also run the unit tests first, if you want to make sure to restart if the code is in a correct state:
+
+```sh
+gw /path/to/repo -s 'npm run test' -p 'npm run start'
+```
+
+If you want to use a build step, for example for TypeScript or Next.js, look at the [TypeScript guide](/guides/compiled#typescript).
 
 ### Python
 

--- a/docs/content/guides/netlify.md
+++ b/docs/content/guides/netlify.md
@@ -7,7 +7,7 @@ weight = 7
 
 If you want to generate a version for every commit of your code, and expose it as hashes, you can `gw` and environment variables.
 
-> Note: This solution **won't** be exactly like Netlify, it won't have the web UI, on-click rollbacks, etc. As this already requires a generous amount of ducktape, please be vary of using this on production. If you need all the features of Netlify, just use Netlify.
+> **Note**: This solution **won't** be exactly like Netlify, it won't have the web UI, on-click rollbacks, etc. As this already requires a generous amount of ducktape, please be vary of using this on production. If you need all the features of Netlify, just use Netlify.
 
 ## Project configuration
 
@@ -26,20 +26,20 @@ npx @11ty/eleventy --input=. --output=output/$GW_GIT_COMMIT_SHORT_SHA
 You can use this command to configure your `gw`:
 
 ```sh
-gw /path/to/repo -s 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA'
+gw /path/to/repo -S 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA'
 ```
 
 To build another version for the latest you can copy the files to another folder:
 
 ```sh
-gw /path/to/repo -s 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA' -s 'cp -r output/$GW_GIT_COMMIT_SHORT_SHA output/latest'
+gw /path/to/repo -S 'jekyll build --destination=output/$GW_GIT_COMMIT_SHORT_SHA' -S 'cp -r output/$GW_GIT_COMMIT_SHORT_SHA output/latest'
 ```
 
 ## Web server configuration
 
 One extra setup that you have to do is point your web server to this directory. By default you can use it as path prefixes, but it can be configured to sub domains to these directories. That way you could reach the commit `0c431ff1` on the url `0c431ff1.example.net`.
 
-> Make sure to setup wildcard domains in your DNS server so it redirects all domains to your server!
+> **Note**: Make sure to setup wildcard domains in your DNS server so it redirects all domains to your server!
 
 ## Nginx
 

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -6,3 +6,5 @@ weight = 200
 paginate_by = 1000
 insert_anchor_links = "right"
 +++
+
+The reference contains detailed information about the inner workings of `gw`.

--- a/docs/content/reference/authentication.md
+++ b/docs/content/reference/authentication.md
@@ -13,7 +13,7 @@ To debug authentication issues, it is recommended to run `gw` with `-vvv` (traci
 
 For SSH it is recommended to use the ssh-keys that you are already using on your system. If you cloned the repository with a user, you can use the same user to run `gw`. If you are running `gw` in a container, you can mount the whole `.ssh` folder into `/root/.ssh` (`.ssh/known_hosts` is usually needed as well).
 
-> Note: If you only running `gw` for a single repository, for improved security use read-only [Deploy keys](#deploy-keys).
+> **Note**: If you only running `gw` for a single repository, for improved security use read-only [Deploy keys](#deploy-keys).
 
 By default SSH authentication checks these files for credentials:
 
@@ -62,7 +62,7 @@ gw /path/to/repo --ssh-key ~/.ssh/id_deploy
 
 Even though it is less common on servers, you can also use HTTPS for pulling repositories. By default `gw` will check credential helpers to extract username and passwords. If you want to set a username and password manually you can use the `--git-username` and `--git-token` fields.
 
-> Note: **Never** use your password as the `--git-token`, always use read-only [repository-level tokens](#repository-level-tokens) instead.
+> **Note**: **Never** use your password as the `--git-token`, always use read-only [repository-level tokens](#repository-level-tokens) instead.
 
 ```sh
 gw /path/to/repo --git-username username --git-token f7818t23fb1amsc

--- a/docs/content/reference/commandline.md
+++ b/docs/content/reference/commandline.md
@@ -1,5 +1,5 @@
 +++
-title = "Command-line arguments"
+title = "CLI arguments"
 weight = 2
 +++
 

--- a/docs/content/reference/environment-variables.md
+++ b/docs/content/reference/environment-variables.md
@@ -1,5 +1,5 @@
 +++
-title = "Environment variables"
+title = "Env variables"
 weight = 3
 +++
 
@@ -9,7 +9,7 @@ The different steps can add variables to the context, which are exposed to the s
 All of these are prefixed with `GW_` to avoid collisions. The second part usually identifies the specific trigger,
 check or action.
 
-A good way to debug environment variables is to print the variables with `--script "printenv"`.
+A good way to debug environment variables is to print the variables with `-s "printenv"`.
 
 ## Trigger variables
 
@@ -41,9 +41,9 @@ These are the variables that are exposed from the check, which currently is alwa
 
 ## Action variables
 
-These are the variables added by the action, which currently is always script.
+These are the variables added by the action, which is script or process.
 
-| Variable name    | Example        | Notes                                       |
-| ---------------- | -------------- | ------------------------------------------- |
-| `GW_ACTION_NAME` | `SCRIPT`       | The identifier of the action.               |
-| `GW_DIRECTORY`   | `/src/http/gw` | The absolute path to the current directory. |
+| Variable name    | Example             | Notes                                       |
+| ---------------- | ------------------- | ------------------------------------------- |
+| `GW_ACTION_NAME` | `SCRIPT`, `PROCESS` | The identifier of the action.               |
+| `GW_DIRECTORY`   | `/src/http/gw`      | The absolute path to the current directory. |

--- a/docs/content/usage/actions.md
+++ b/docs/content/usage/actions.md
@@ -5,7 +5,7 @@ weight = 3
 
 # Actions on pull
 
-The main point of `gw` is to do actions every time there code is pulled. There are multiple actions: running a script or restarting a background process.
+The main point of `gw` is to do actions every time there code is pulled. There are multiple actions: running a script or restarting a background process. The order of the actions matter, and they will be executed sequentially based on the order of the command-line arguments.
 
 ## Scripts
 
@@ -25,7 +25,7 @@ $ gw /path/to/repo -v -s 'echo "updated"'
 2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   update
 ```
 
-Scripts are always run first of all actions and run in a shell (`/bin/sh` on Linux and `cmd` on Windows). This way you can expand variables and use shell features e.g. pipes or multiple commands. The full enviroment is passed to scripts with a number of [gw-specific environment variables](/reference/environment-variables). If you want to use variables make sure to use singlequotes so they aren't expanded beforehand.
+Scripts are run in a shell: `/bin/sh` on Linux and `cmd` on Windows. This way you can expand variables and use shell features e.g. pipes or multiple commands. The full enviroment is passed to scripts with a number of [gw-specific environment variables](/reference/environment-variables). If you want to use variables make sure to use singlequotes so they aren't expanded beforehand.
 
 ```sh
 gw /path/to/repo -s 'ls -l $BUILD_DIRECTORY | wc -l'
@@ -57,7 +57,11 @@ $ gw /path/to/repo -v -s 'ping 1.1.1.1'
 2024-10-16T18:04:25.906Z DEBUG [gw_bin::actions::process] [ping] 64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=16.8 ms
 ```
 
-Unlike scripts, you can only define one process and they are executed directly instead of in a shell. Processes also can't access gw-specific environment variables. 
+Unlike scripts, you can only define one process and they are executed directly instead of in a shell. Processes also can't access gw-specific environment variables. Scripts defined before process will be run before the restart and if defined after they will run after.
+
+```sh
+gw /path/to/repo -s 'echo this runs before' -p 'ping 1.1.1.1' -s 'echo this runs after'
+```
 
 If a process fails, by default it marked failed and an error printed. If you want to retry the process you can set the `--process-retries` flag:
 

--- a/docs/content/usage/actions.md
+++ b/docs/content/usage/actions.md
@@ -15,27 +15,41 @@ The simplest action is to run a command on pull with `--script` or `-s`:
 gw /path/to/repo -s 'echo "updated"'
 ```
 
-You can define multiple scripts, these will run one after another (there is currently no way to parallelise these). The output of the script is not printed by default, you can increase verbosity (`-v`) to get output from the script:
+You can define multiple scripts, these will run one after another (there is currently no way to parallelise these). If one of the scripts fail, the other scripts won't run at all. You can use scripts to run tests before updating your code.
+
+```sh
+gw /path/to/repo -s 'echo "testing"' -s 'echo "updating"'
+```
+
+> **Note**: If you have more than 2-3 scripts on every pull it might be worth it to refactor it into an `update.sh` shell script. It can contain logic and be commited which helps if you want to change it without updating the gw process.
+
+The output of the script is not printed by default, you can increase verbosity (`-v`) to get output from the script:
 
 ```sh
 $ gw /path/to/repo -v -s 'echo "updated"'
-2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
-2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: echo "updated" in directory /path/to/repo.
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   update
+2024-10-18T16:28:53.907Z INFO  [gw_bin::start] There are updates, running actions.
+2024-10-18T16:28:53.907Z INFO  [gw_bin::actions::script] Running script "echo" in /path/to/repo.
+2024-10-18T16:28:53.913Z DEBUG [gw_bin::actions::script] [echo] updated
+2024-10-18T16:28:53.913Z INFO  [gw_bin::actions::script] Script "echo" finished successfully.
 ```
 
-Scripts are run in a shell: `/bin/sh` on Linux and `cmd` on Windows. This way you can expand variables and use shell features e.g. pipes or multiple commands. The full enviroment is passed to scripts with a number of [gw-specific environment variables](/reference/environment-variables). If you want to use variables make sure to use singlequotes so they aren't expanded beforehand.
+By default, scripts are executed directly to avoid common issues with shells (e.g. shell injection and unexpected globbing). If you instead want to run in a shell to expand variables or use shell specific functionality (e.g. pipes or multiple commands), use the `-S` flag. These scripts will run in a shell: `/bin/sh` on Linux and `cmd.exe` on Windows.
 
 ```sh
-gw /path/to/repo -s 'ls -l $BUILD_DIRECTORY | wc -l'
+gw /path/to/repo -S 'ls -l . | wc -l'
+```
+
+The full enviroment is passed to scripts with a number of [gw-specific environment variables](/reference/environment-variables). If you want to use variables make sure to use singlequotes so they aren't expanded beforehand.
+
+```sh
+gw /path/to/repo -S 'ls -l $BUILD_DIRECTORY | wc -l'
 ```
 
 Best use-cases for scripts:
 
-- [compile](/guides/compiled) or transpile your code,
-- rebuild some assets,
-- restart or reload a separately running program.
+-   [compile](/guides/compiled) or transpile your code,
+-   rebuild some assets,
+-   restart or reload a separately running program.
 
 ## Processes
 
@@ -51,13 +65,17 @@ Processes are started when `gw` is started and they are kept in the background. 
 $ gw /path/to/repo -v -s 'ping 1.1.1.1'
 2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
 2024-10-16T18:04:25.888Z INFO  [gw_bin::actions::process] Starting process "ping" in /path/to/repo.
-2024-10-16T18:04:25.888Z DEBUG [gw_bin::start] Waiting on triggers.
-2024-10-16T18:04:25.888Z INFO  [gw_bin::triggers::schedule] Starting schedule in every 1m.
 2024-10-16T18:04:25.906Z DEBUG [gw_bin::actions::process] [ping] PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
 2024-10-16T18:04:25.906Z DEBUG [gw_bin::actions::process] [ping] 64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=16.8 ms
 ```
 
-Unlike scripts, you can only define one process and they are executed directly instead of in a shell. Processes also can't access gw-specific environment variables. Scripts defined before process will be run before the restart and if defined after they will run after.
+Similarly to scripts, processes are executed directly. If you want to use the native shell for variable expansion or shell-specific functionality, you can use `-P`.
+
+```sh
+gw /path/to/repo -P 'ping $TARGET_IP'
+```
+
+Unlike scripts, you can only define one process. Processes also can't access gw-specific environment variables. Scripts defined before process will be run before the restart and if defined after they will run after. If any of the scripts before the process fails the process will not be restarted. You can add tests and other checks to only restart the process if the code is 100% correct.
 
 ```sh
 gw /path/to/repo -s 'echo this runs before' -p 'ping 1.1.1.1' -s 'echo this runs after'
@@ -77,6 +95,6 @@ gw /path/to/repo -v -s 'ping 1.1.1.1' --stop-signal SIGTERM --stop-timeout 10s
 
 Best use-cases for processes:
 
-- run [interpreted programs](/guides/interpreted) e.g. web frameworks,
-- run binaries after [compiling](/guides/compiled),
-- run external programs to restart [on config change](/guides/configuration).
+-   run [interpreted programs](/guides/interpreted) e.g. web frameworks,
+-   run binaries after [compiling](/guides/compiled),
+-   run external programs to restart [on config change](/guides/configuration).

--- a/docs/content/usage/docker.md
+++ b/docs/content/usage/docker.md
@@ -50,7 +50,7 @@ If you are using ssh-keys, mount the `.ssh` directory as well, so it can pull. F
 
 Most applications have many dependencies and complicated setups, and are already running on Docker. In these cases it is often preferable to build the `gw` image on top of the already existing application image.
 
-**NOTE**: This doesn't mean that these should be running in the same container, but they can use the same base image in two separate containers. It is a common wisdom that one container should run one thing.
+> **Note**: This doesn't mean that these should be running in the same container, but they can use the same base image in two separate containers. It is a common wisdom that one container should run one thing.
 
 For this we can start off of our application image as a base layer and add the `gw` binary in a `COPY` layer. You can simply wrap your existing command using subprocess mode (`-p`) and it will restart the script every time a pull happened.
 

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -60,10 +60,10 @@ This will run every time there is a new commit, and after the pull it will print
 ```sh
 $ gw /path/to/repo -v --script 'cat DATETIME'
 # ...
-2024-03-10T15:04:37.740Z INFO  [gw_bin::start] There are updates, running actions.
-2024-03-10T15:04:37.740Z DEBUG [gw_bin::actions::script] Running script: cat DATETIME in directory /path/to/repo.
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script] Command success, output:
-2024-03-10T15:04:37.742Z DEBUG [gw_bin::actions::script]   2024-03-10T15:04:01+0000
+2024-10-18T16:28:53.907Z INFO  [gw_bin::start] There are updates, running actions.
+2024-10-18T16:28:53.907Z INFO  [gw_bin::actions::script] Running script "cat" in /path/to/repo.
+2024-10-18T16:28:53.913Z DEBUG [gw_bin::actions::script] [cat] 2024-10-18T16:28:00+0000
+2024-10-18T16:28:53.913Z INFO  [gw_bin::actions::script] Script "cat" finished successfully.
 ```
 
 You can add multiple scripts, which will run one after another. Use these scripts to build source files, restarts deployments and anything else that you can imagine.
@@ -101,8 +101,9 @@ If you want to put the `gw` script in the background, you can:
 If you are interested in some ideas on how to use `gw`:
 
 - if you only need to pull files, see [PHP guide](/guides/php);
-- if you are using a compiled language, see [Guide for compiled languages](/guides/compiled) for example on restarting a process;
-- if you want to use `gw` with a `docker-compose.yaml`, see [Guide for docker-compose](guides/docker-compose);
+- if you are using a dynamic language (e.g. JavaScript, Python, Ruby), see [Guide for dynamic languages](/guides/dynamic) for example on running a process;
+- if you are using a compiled language (e.g. TypeScript, Go, Rust), see [Guide for compiled languages](/guides/compiled) for example on compiling a program;
+- if you use a `docker-compose.yaml`, see [Guide for docker-compose](guides/docker-compose);
 - if you want to easily manage configuration files as GitOps, see [Configuration guide](/guides/configuration);
 - for a full-blown example, check out [Netlify](/guides/netlify);
 - and many other things, for the incomplete list [guides page](/guides).

--- a/docs/content/usage/systemd.md
+++ b/docs/content/usage/systemd.md
@@ -20,7 +20,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/gw /path/to/repo --script "echo ran from systemctl unit"
+ExecStart=/usr/bin/gw /path/to/repo -s 'echo ran from systemctl unit'
 Restart=always
 # run as a non-root user (recommended)
 User=myuser

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 pub mod process;
 /// An action to run a custom shell script.
 pub mod script;
+/// Utilities for shared code
+pub mod utils;
 
 /// A custom error for describing the error cases for actions
 #[derive(Debug, Error)]

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -213,7 +213,7 @@ mod tests {
         testing_logger::setup();
 
         let command = String::from(PRINTENV);
-        let action = ScriptAction::new(String::from("."), command, false)?;
+        let action = ScriptAction::new(String::from("."), command, true)?;
 
         let context: Context = HashMap::from([
             ("TRIGGER_NAME", "TEST-TRIGGER".to_string()),
@@ -239,7 +239,7 @@ mod tests {
         std::env::set_var("GW_TEST", "GW_TEST");
 
         let command = String::from(PRINTENV);
-        let action = ScriptAction::new(String::from("."), command, false)?;
+        let action = ScriptAction::new(String::from("."), command, true)?;
 
         let context: Context = HashMap::new();
         action.run_inner(&context)?;

--- a/src/actions/utils/command.rs
+++ b/src/actions/utils/command.rs
@@ -1,0 +1,42 @@
+use duct::{cmd, Expression};
+use duct_sh::sh_dangerous;
+use log::{trace, warn};
+
+pub fn create_command(original_command: &str, runs_in_shell: bool) -> Option<(String, Expression)> {
+    // If we are not in a shell, test if the user might want to be in one (uses variables or pipes)
+    if !runs_in_shell {
+        let contains_variables = original_command
+            .find('$')
+            .and_then(|pos| original_command.chars().nth(pos + 1))
+            .map(|ch| ch.is_ascii_alphabetic() || ch == '{')
+            == Some(true);
+
+        let contains_suspicious = original_command.contains(" | ")
+            || original_command.contains(" && ")
+            || original_command.contains(" || ");
+
+        if contains_variables || contains_suspicious {
+            warn!("The command {original_command:?} contains a variable or other shell-specific character: you might want to run it in a shell (-S or -P).")
+        }
+    }
+
+    // We have to split the command into parts to get the command id
+    let split_args = shlex::split(original_command)?;
+    let (command, args) = split_args.split_first()?;
+
+    trace!(
+        "Parsing {:?} to command {:?} and args {:?}.",
+        &original_command,
+        &command,
+        &args
+    );
+
+    // If we are in a shell we can `sh_dangerous`, otherwise avoid bugs around shells
+    let script = if runs_in_shell {
+        sh_dangerous(original_command)
+    } else {
+        cmd(command, args)
+    };
+
+    Some((command.clone(), script))
+}

--- a/src/actions/utils/command.rs
+++ b/src/actions/utils/command.rs
@@ -24,19 +24,14 @@ pub fn create_command(original_command: &str, runs_in_shell: bool) -> Option<(St
     let split_args = shlex::split(original_command)?;
     let (command, args) = split_args.split_first()?;
 
-    trace!(
-        "Parsing {:?} to command {:?} and args {:?}.",
-        &original_command,
-        &command,
-        &args
-    );
-
     // If we are in a shell we can `sh_dangerous`, otherwise avoid bugs around shells
     let script = if runs_in_shell {
         sh_dangerous(original_command)
     } else {
         cmd(command, args)
     };
+
+    trace!("Parsed {original_command:?} to {script:?}.");
 
     Some((command.clone(), script))
 }

--- a/src/actions/utils/mod.rs
+++ b/src/actions/utils/mod.rs
@@ -1,0 +1,2 @@
+/// Utilities for handling commands
+pub mod command;

--- a/src/args.rs
+++ b/src/args.rs
@@ -31,9 +31,17 @@ pub struct Args {
     #[options(long = "script")]
     pub scripts: Vec<String>,
 
+    /// Run the script to run on changes in a shell.
+    #[options(short = "S", no_long)]
+    pub scripts_with_shell: Vec<String>,
+
     /// A background process that will be restarted on change.
     #[options()]
     pub process: Option<String>,
+
+    /// Run a background process in a shell.
+    #[options(short = "P", no_long)]
+    pub process_with_shell: Option<String>,
 
     /// Try to pull only once. Useful for cronjobs.
     #[options(long = "once", no_short)]
@@ -100,8 +108,8 @@ pub struct Args {
 
 #[derive(Debug)]
 pub enum ArgAction {
-    Process(String),
-    Script(String),
+    Process(String, bool),
+    Script(String, bool),
 }
 
 pub fn parse_args() -> (Args, Vec<ArgAction>) {
@@ -112,9 +120,13 @@ pub fn parse_args() -> (Args, Vec<ArgAction>) {
         .skip(2)
         .filter_map(|arg| {
             if args.process.as_ref() == Some(&arg) {
-                Some(ArgAction::Process(arg))
+                Some(ArgAction::Process(arg, false))
+            } else if args.process_with_shell.as_ref() == Some(&arg) {
+                Some(ArgAction::Process(arg, true))
             } else if args.scripts.contains(&arg) {
-                Some(ArgAction::Script(arg))
+                Some(ArgAction::Script(arg, false))
+            } else if args.scripts_with_shell.contains(&arg) {
+                Some(ArgAction::Script(arg, true))
             } else {
                 None
             }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use duration_string::DurationString;
 use gumdrop::Options;
-use std::str::FromStr;
+use std::{env, str::FromStr};
 
 #[derive(Clone, Debug)]
 pub enum Trigger {
@@ -98,6 +98,28 @@ pub struct Args {
     pub help: bool,
 }
 
-pub fn parse_args() -> Args {
-    Args::parse_args_default_or_exit()
+#[derive(Debug)]
+pub enum ArgAction {
+    Process(String),
+    Script(String),
+}
+
+pub fn parse_args() -> (Args, Vec<ArgAction>) {
+    let args = Args::parse_args_default_or_exit();
+
+    // We have to maintain positionality between different flags
+    let arg_actions = env::args()
+        .skip(2)
+        .filter_map(|arg| {
+            if args.process.as_ref() == Some(&arg) {
+                Some(ArgAction::Process(arg))
+            } else if args.scripts.contains(&arg) {
+                Some(ArgAction::Script(arg))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    (args, arg_actions)
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -25,22 +25,22 @@ pub struct Args {
     #[options(free)]
     pub directory: Option<String>,
 
-    /// The script to run on changes, you can define multiple times.
+    /// A script to run on changes, you can define multiple times.
     ///
     /// If there are no scripts given, it will only pull.
-    #[options(long = "script")]
+    #[options(long = "script", meta = "SCRIPT")]
     pub scripts: Vec<String>,
 
-    /// Run the script to run on changes in a shell.
-    #[options(short = "S", no_long)]
+    /// Run a script in a shell.
+    #[options(short = "S", no_long, meta = "SCRIPT")]
     pub scripts_with_shell: Vec<String>,
 
     /// A background process that will be restarted on change.
-    #[options()]
+    #[options(meta = "PROCESS")]
     pub process: Option<String>,
 
     /// Run a background process in a shell.
-    #[options(short = "P", no_long)]
+    #[options(short = "P", no_long, meta = "PROCESS")]
     pub process_with_shell: Option<String>,
 
     /// Try to pull only once. Useful for cronjobs.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ pub enum MainError {
     MissingDirectoryArg,
     #[error("Directory {0} not found.")]
     NonExistentDirectory(String),
+    #[error("You cannot start multiple processes, only add -p or -P once.")]
+    MultipleProcessArgs,
     #[error("Check failed: {0}.")]
     FailedCheck(#[from] CheckError),
     #[error("Failed setting up logger.")]
@@ -94,6 +96,14 @@ fn main_inner() -> Result<(), MainError> {
     let mut check: Box<dyn Check> = Box::new(git_check);
 
     // Setup actions.
+    if arg_actions
+        .iter()
+        .filter(|a| matches!(a, ArgAction::Process(_, _)))
+        .count()
+        > 1
+    {
+        return Err(MainError::MultipleProcessArgs);
+    }
     let mut actions: Vec<Box<dyn Action>> = vec![];
     for arg_action in arg_actions {
         match arg_action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,14 +97,18 @@ fn main_inner() -> Result<(), MainError> {
     let mut actions: Vec<Box<dyn Action>> = vec![];
     for arg_action in arg_actions {
         match arg_action {
-            ArgAction::Script(script) => {
+            ArgAction::Script(script, runs_in_shell) => {
                 debug!("Setting up ScriptAction {script:?} on change.");
-                actions.push(Box::new(ScriptAction::new(directory.clone(), script)));
+                actions.push(Box::new(
+                    ScriptAction::new(directory.clone(), script, runs_in_shell)
+                        .map_err(ActionError::from)?,
+                ));
             }
-            ArgAction::Process(process) => {
+            ArgAction::Process(process, runs_in_shell) => {
                 debug!("Setting up ProcessAction {process:?} on change.");
                 let mut process_params =
-                    ProcessParams::new(process, directory.clone()).map_err(ActionError::from)?;
+                    ProcessParams::new(process, directory.clone(), runs_in_shell)
+                        .map_err(ActionError::from)?;
 
                 if let Some(retries) = args.process_retries {
                     process_params.set_retries(retries);

--- a/src/start.rs
+++ b/src/start.rs
@@ -54,7 +54,11 @@ pub fn start(
                     }
                 );
                 for action in actions.iter_mut() {
-                    let _ = action.run(&context);
+                    let result = action.run(&context);
+                    if let Err(err) = result {
+                        error!("Action failed, we will not continue: {err}.");
+                        break;
+                    }
                 }
             }
             Ok(false) => {


### PR DESCRIPTION
**Motivation**: Currently scripts run in a shell (legacy reasons) while processes are executed directly. These behaviour should be in line, making the default to execute directly and add a new flag to execute in a shell. The positionality of the flags should remain, even with the process (before and after scripts).

- Update documentation
- Disallow starting multiple processes
- Add behaviour that stops if either action failed
- Refactor logging a bit
- Add args to run actions in a shell
- Refactor script to be similar to process
- Maintain positionality between process and script
