### PR TITLE
Allow the user to press Ctrl+C a second time to immediately exit the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Only change gitconfig (safe.directory) if there isn't one
 - Don't overwrite script environment, use already set variables
+- If the user presses Ctrl+C a second time, the program exits immediately
 
 ## [0.3.2] - 2024-08-26
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main_inner() -> Result<(), MainError> {
         .to_string();
 
     // Setup triggers.
-    let mut triggers: Vec<Box<dyn Trigger>> = vec![Box::new(SignalTrigger)];
+    let mut triggers: Vec<Box<dyn Trigger>> = vec![Box::new(SignalTrigger::new())];
     if args.once {
         debug!("Setting up OnceTrigger (this will disable all other triggers).");
         triggers.push(Box::new(OnceTrigger));
@@ -108,12 +108,14 @@ fn main_inner() -> Result<(), MainError> {
             process_params.set_retries(retries);
         }
         if let Some(stop_signal) = args.stop_signal {
-            process_params.set_stop_signal(stop_signal).map_err(ActionError::from)?;
+            process_params
+                .set_stop_signal(stop_signal)
+                .map_err(ActionError::from)?;
         }
         if let Some(stop_timeout) = args.stop_timeout {
             process_params.set_stop_timeout(stop_timeout.into());
         }
- 
+
         actions.push(Box::new(
             ProcessAction::new(process_params).map_err(ActionError::from)?,
         ));

--- a/src/triggers/signal.rs
+++ b/src/triggers/signal.rs
@@ -1,18 +1,23 @@
 use super::{Trigger, TriggerError};
 use crate::context::Context;
+use std::sync::mpsc::Sender;
 use log::debug;
-use std::sync::{atomic::AtomicU8, mpsc::Sender};
+
+#[cfg(unix)]
+use std::sync::atomic::AtomicU8;
 
 const _TRIGGER_NAME: &str = "SIGNAL";
 
 /// A trigger that terminates the program on a signal.
 pub struct SignalTrigger {
+    #[cfg(unix)]
     trigger_count: AtomicU8,
 }
 
 impl SignalTrigger {
     pub fn new() -> SignalTrigger {
         SignalTrigger {
+            #[cfg(unix)]
             trigger_count: AtomicU8::new(0),
         }
     }


### PR DESCRIPTION
**Motivation**: Currently the program only does a clean shutdown on Ctrl+C. If there is a long script that is stuck, you cannot exit, because the program will wait until it cleanly finishes. If the user presses Ctrl+C a second time, the program should exit immediately (or with a little delay to allow the clean finish anyways) so it can get unstuck.

- Allow the user to press Ctrl+C twice to shutdown the application immediately
