### PR TITLE
Add tests for MacOS and Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Test for linting issues
         run: cargo clippy -- -D warnings
+      - name: Debug with SSHX
+        run: curl -sSf https://sshx.io/get | sh -s run
       - name: Setup git configuration
         run: |
           git config --global user.email "test@example.com"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,12 @@ on:
 
 jobs:
   test:
-    name: Test on every commit
-    runs-on: ubuntu-latest
+    strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Check and test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the tag
         uses: actions/checkout@v3
@@ -16,21 +20,10 @@ jobs:
           toolchain: stable
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - name: Restore cached dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Test for linting issues
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -Dwarnings
+        run: cargo clippy -- -D warnings
       - name: Setup git configuration
         run: |
           git config --global user.email "test@example.com"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,4 +30,6 @@ jobs:
           git config --global user.name "Test Thomas"
           git config --global init.defaultBranch master
       - name: Run tests
-        run: RUST_BACKTRACE=1 cargo nextest run --no-fail-fast
+        run: cargo nextest run --no-fail-fast
+        env:
+          RUST_BACKTRACE: "1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Test for linting issues
         run: cargo clippy -- -D warnings
-      - name: Debug with SSHX
-        run: curl -sSf https://sshx.io/get | sh -s run
       - name: Setup git configuration
         run: |
           git config --global user.email "test@example.com"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,4 +30,4 @@ jobs:
           git config --global user.name "Test Thomas"
           git config --global init.defaultBranch master
       - name: Run tests
-        run: cargo nextest run --no-fail-fast
+        run: RUST_BACKTRACE=1 cargo nextest run --no-fail-fast

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,9 @@ on:
 jobs:
   test:
     strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     name: Check and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,5 +31,3 @@ jobs:
           git config --global init.defaultBranch master
       - name: Run tests
         run: cargo nextest run --no-fail-fast
-        env:
-          RUST_BACKTRACE: "1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,4 +30,4 @@ jobs:
           git config --global user.name "Test Thomas"
           git config --global init.defaultBranch master
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run --no-fail-fast

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -369,23 +369,28 @@ impl Action for ProcessAction {
 }
 
 #[cfg(test)]
+#[cfg_attr(not(unix), allow(unused_imports))]
 mod tests {
     use super::*;
     use std::{fs, time::Instant};
     use thread::sleep;
 
-    const EXIT_NONZERO: &str = "exit 1";
+    const SLEEP_PARSING: &str = "sleep 100";
     const SLEEP_INVALID: &str = "sleep '100";
 
     #[cfg(unix)]
+    const EXIT_NONZERO: &str = "/bin/sh -c 'exit 1'";
+    #[cfg(unix)]
     const SLEEP: &str = "sleep 100";
 
+    #[cfg(not(unix))]
+    const EXIT_NONZERO: &str = "cmd /c 'exit 1'";
     #[cfg(not(unix))]
     const SLEEP: &str = "timeout /t 100";
 
     #[test]
     fn it_should_start_a_new_process() -> Result<(), ProcessError> {
-        let params = ProcessParams::new(String::from(SLEEP), String::from("."))?;
+        let params = ProcessParams::new(String::from(SLEEP_PARSING), String::from("."))?;
         let mut action = ProcessAction::new(params)?;
         action.process.stop()?;
 

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -97,17 +97,21 @@ impl ProcessParams {
         self.retries = retries;
     }
 
-    #[cfg(unix)]
     pub fn set_stop_signal(&mut self, stop_signal: String) -> Result<(), ProcessError> {
-        self.stop_signal = Signal::from_str(&stop_signal)
-            .map_err(|_| ProcessError::SignalParseFailure(stop_signal))?;
+        #[cfg(unix)]
+        {
+            self.stop_signal = Signal::from_str(&stop_signal)
+                .map_err(|_| ProcessError::SignalParseFailure(stop_signal))?;
+        }
 
         Ok(())
     }
 
-    #[cfg(unix)]
     pub fn set_stop_timeout(&mut self, stop_timeout: Duration) {
-        self.stop_timeout = stop_timeout;
+        #[cfg(unix)]
+        {
+            self.stop_timeout = stop_timeout;
+        }
     }
 }
 

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -97,6 +97,7 @@ impl ProcessParams {
         self.retries = retries;
     }
 
+    #[cfg_attr(not(unix), allow(unused_variables))]
     pub fn set_stop_signal(&mut self, stop_signal: String) -> Result<(), ProcessError> {
         #[cfg(unix)]
         {
@@ -107,6 +108,7 @@ impl ProcessParams {
         Ok(())
     }
 
+    #[cfg_attr(not(unix), allow(unused_variables))]
     pub fn set_stop_timeout(&mut self, stop_timeout: Duration) {
         #[cfg(unix)]
         {

--- a/src/actions/process.rs
+++ b/src/actions/process.rs
@@ -2,16 +2,18 @@ use super::{Action, ActionError};
 use crate::context::Context;
 use duct::ReaderHandle;
 use log::{debug, error, info, trace, warn};
-use nix::{errno::Errno, sys::signal::Signal};
 use std::{
     io::{BufRead, BufReader},
-    os::unix::process::ExitStatusExt,
-    str::FromStr,
     sync::{Arc, RwLock},
     thread::{self, sleep},
     time::Duration,
 };
 use thiserror::Error;
+
+#[cfg(unix)]
+use nix::{errno::Errno, sys::signal::Signal};
+#[cfg(unix)]
+use std::{os::unix::process::ExitStatusExt, str::FromStr};
 
 const ACTION_NAME: &str = "PROCESS";
 

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -115,9 +115,10 @@ mod tests {
     use std::collections::HashMap;
 
     const ECHO_TEST: &str = "echo test";
-    const ECHO_INVALID_UNICODE: &str = "python -c \"import sys; sys.stdout.buffer.write(b'\\xc3\\x28')\"";
     const EXIT_NONZERO: &str = "exit 1";
-
+    
+    #[cfg(unix)]
+    const ECHO_INVALID_UNICODE: &str = "python -c \"import sys; sys.stdout.buffer.write(b'\\xc3\\x28')\"";
     #[cfg(unix)]
     const ECHO_STDERR: &str = "printf err >&2";
     #[cfg(unix)]
@@ -211,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn it_should_fail_if_the_script_returns_non_utf8() -> Result<(), ScriptError> {
         let command = String::from(ECHO_INVALID_UNICODE);
         let action = ScriptAction::new(String::from("."), command);

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -114,17 +114,25 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    const ECHO_TEST: &str = "printf test";
+    const ECHO_STDERR: &str = "printf err >&2";
+    const ECHO_INVALID_UNICODE: &str = "/bin/printf '\\xc3\\x28'";
+    const PRINTENV: &str = "printenv";
+    const FALSE: &str = "false";
+
     #[test]
     fn it_should_create_new_script() {
-        let action = ScriptAction::new(String::from("."), String::from("printf test"));
+        let command = String::from(ECHO_TEST);
+        let action = ScriptAction::new(String::from("."), command);
 
-        assert_eq!("printf test", action.command);
+        assert_eq!(ECHO_TEST, action.command);
         assert_eq!(".", action.directory);
     }
 
     #[test]
     fn it_should_run_the_script() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("printf test"));
+        let command = String::from(ECHO_TEST);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();
         let output = action.run_inner(&context)?;
@@ -135,7 +143,8 @@ mod tests {
 
     #[test]
     fn it_should_set_the_env_vars() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("printenv"));
+        let command = String::from(PRINTENV);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::from([
             ("TRIGGER_NAME", "TEST-TRIGGER".to_string()),
@@ -156,7 +165,8 @@ mod tests {
     fn it_should_keep_the_already_set_env_vars() -> Result<(), ScriptError> {
         std::env::set_var("GW_TEST", "GW_TEST");
 
-        let action = ScriptAction::new(String::from("."), String::from("printenv"));
+        let command = String::from(PRINTENV);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();
         let output = action.run_inner(&context)?;
@@ -168,7 +178,8 @@ mod tests {
 
     #[test]
     fn it_should_catch_error_output() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("printf err >&2"));
+        let command = String::from(ECHO_STDERR);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();
         let output = action.run_inner(&context)?;
@@ -179,7 +190,8 @@ mod tests {
 
     #[test]
     fn it_should_fail_if_the_script_fails() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("false"));
+        let command = String::from(FALSE);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();
         let result = action.run_inner(&context);
@@ -193,8 +205,8 @@ mod tests {
 
     #[test]
     fn it_should_fail_if_the_script_returns_non_utf8() -> Result<(), ScriptError> {
-        let action =
-            ScriptAction::new(String::from("."), String::from("printf '\\xc3\\x28'"));
+        let command = String::from(ECHO_INVALID_UNICODE);
+        let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();
         let result = action.run_inner(&context);

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -116,15 +116,15 @@ mod tests {
 
     #[test]
     fn it_should_create_new_script() {
-        let action = ScriptAction::new(String::from("."), String::from("echo test"));
+        let action = ScriptAction::new(String::from("."), String::from("printf test"));
 
-        assert_eq!("echo test", action.command);
+        assert_eq!("printf test", action.command);
         assert_eq!(".", action.directory);
     }
 
     #[test]
     fn it_should_run_the_script() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("echo test"));
+        let action = ScriptAction::new(String::from("."), String::from("printf test"));
 
         let context: Context = HashMap::new();
         let output = action.run_inner(&context)?;
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn it_should_catch_error_output() -> Result<(), ScriptError> {
-        let action = ScriptAction::new(String::from("."), String::from("echo err >&2"));
+        let action = ScriptAction::new(String::from("."), String::from("printf err >&2"));
 
         let context: Context = HashMap::new();
         let output = action.run_inner(&context)?;
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn it_should_fail_if_the_script_returns_non_utf8() -> Result<(), ScriptError> {
         let action =
-            ScriptAction::new(String::from("."), String::from("/bin/echo -e '\\xc3\\x28'"));
+            ScriptAction::new(String::from("."), String::from("printf '\\xc3\\x28'"));
 
         let context: Context = HashMap::new();
         let result = action.run_inner(&context);

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -114,11 +114,17 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    const ECHO_TEST: &str = "printf test";
+    const ECHO_TEST: &str = "echo test";
+    const ECHO_INVALID_UNICODE: &str = "python -c \"import sys; sys.stdout.buffer.write(b'\\xc3\\x28')\"";
+    const EXIT_NONZERO: &str = "exit 1";
+
+    #[cfg(unix)]
     const ECHO_STDERR: &str = "printf err >&2";
-    const ECHO_INVALID_UNICODE: &str = "/usr/bin/printf '\\xc3\\x28'";
+    #[cfg(unix)]
     const PRINTENV: &str = "printenv";
-    const FALSE: &str = "false";
+
+    #[cfg(not(unix))]
+    const PRINTENV: &str = "set";
 
     #[test]
     fn it_should_create_new_script() {
@@ -177,6 +183,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn it_should_catch_error_output() -> Result<(), ScriptError> {
         let command = String::from(ECHO_STDERR);
         let action = ScriptAction::new(String::from("."), command);
@@ -190,7 +197,7 @@ mod tests {
 
     #[test]
     fn it_should_fail_if_the_script_fails() -> Result<(), ScriptError> {
-        let command = String::from(FALSE);
+        let command = String::from(EXIT_NONZERO);
         let action = ScriptAction::new(String::from("."), command);
 
         let context: Context = HashMap::new();

--- a/src/actions/script.rs
+++ b/src/actions/script.rs
@@ -116,7 +116,7 @@ mod tests {
 
     const ECHO_TEST: &str = "printf test";
     const ECHO_STDERR: &str = "printf err >&2";
-    const ECHO_INVALID_UNICODE: &str = "/bin/printf '\\xc3\\x28'";
+    const ECHO_INVALID_UNICODE: &str = "/usr/bin/printf '\\xc3\\x28'";
     const PRINTENV: &str = "printenv";
     const FALSE: &str = "false";
 

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -225,12 +225,12 @@ mod tests {
         let remote = format!("{local}-remote");
         let other = format!("{local}-other");
 
-        fs::remove_dir_all(local)?;
+        fs::remove_dir_all(local).unwrap(); // ?;
         if Path::new(&remote).exists() {
-            fs::remove_dir_all(remote)?;
+            fs::remove_dir_all(remote).unwrap(); // ?;
         }
         if Path::new(&other).exists() {
-            fs::remove_dir_all(other)?;
+            fs::remove_dir_all(other).unwrap(); // ?;
         }
 
         Ok(())

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -86,10 +86,7 @@ impl GitCheck {
         Ok(GitCheck(repo))
     }
 
-    pub fn open(
-        directory: &str,
-        additional_host: Option<String>,
-    ) -> Result<Self, CheckError> {
+    pub fn open(directory: &str, additional_host: Option<String>) -> Result<Self, CheckError> {
         setup_known_hosts(additional_host)?;
         setup_gitconfig(directory)?;
 
@@ -359,7 +356,13 @@ mod tests {
             context.get("GIT_BEFORE_COMMIT_SHORT_SHA").unwrap()
         );
         assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
-        assert_eq!(remote, context.get("GIT_REMOTE_URL").unwrap());
+        assert_eq!(
+            remote,
+            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())
+                .unwrap()
+                .to_str()
+                .unwrap()
+        );
 
         cleanup_repository(&local)?;
 
@@ -406,7 +409,13 @@ mod tests {
             context.get("GIT_COMMIT_SHORT_SHA").unwrap()
         );
         assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
-        assert_eq!(remote, context.get("GIT_REMOTE_URL").unwrap());
+        assert_eq!(
+            remote,
+            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())
+                .unwrap()
+                .to_str()
+                .unwrap()
+        );
 
         cleanup_repository(&local)?;
 

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -520,6 +520,11 @@ mod tests {
         perms.set_readonly(true);
         fs::set_permissions(&local, perms)?;
 
+        let perms = fs::metadata(&local)?.permissions();
+        println!("{local}   {:?}", perms.readonly());
+        let perms = fs::metadata(format!("{local}/1"))?.permissions();
+        println!("{local}/1 {:?}", perms.readonly());
+
         let mut check: GitCheck = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -506,6 +506,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn it_should_fail_if_repository_is_not_accessible() -> Result<(), Box<dyn Error>> {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
@@ -519,11 +520,6 @@ mod tests {
         let mut perms = fs::metadata(&local)?.permissions();
         perms.set_readonly(true);
         fs::set_permissions(&local, perms)?;
-
-        let perms = fs::metadata(&local)?.permissions();
-        println!("{local}   {:?}", perms.readonly());
-        let perms = fs::metadata(format!("{local}/1"))?.permissions();
-        println!("{local}/1 {:?}", perms.readonly());
 
         let mut check: GitCheck = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -358,8 +358,7 @@ mod tests {
         assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
         assert_eq!(
             remote,
-            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())
-                .unwrap()
+            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())?
                 .to_str()
                 .unwrap()
         );
@@ -374,24 +373,24 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local)?;
+        create_empty_repository(&local).unwrap(); // ?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local)?;
+        create_other_repository(&local).unwrap(); // ?;
 
-        let before_commit_sha = get_last_commit(&local)?;
-        let mut check = GitCheck::open_inner(&local)?;
+        let before_commit_sha = get_last_commit(&local).unwrap(); // ?;
+        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
         let mut context: Context = HashMap::new();
-        let is_pulled = check.check_inner(&mut context)?;
+        let is_pulled = check.check_inner(&mut context).unwrap(); // ?;
         assert!(is_pulled);
 
         // The pushed file should be pulled
         assert!(Path::new(&format!("{local}/2")).exists());
 
         // It should set the context keys
-        let remote_path = fs::canonicalize(format!("{local}-remote"))?;
+        let remote_path = fs::canonicalize(format!("{local}-remote")).unwrap(); // ?;
         let remote = remote_path.to_str().unwrap();
-        let commit_sha = get_last_commit(&local)?;
+        let commit_sha = get_last_commit(&local).unwrap(); // ?;
         assert_eq!("branch", context.get("GIT_REF_TYPE").unwrap());
         assert_eq!("refs/heads/master", context.get("GIT_REF_NAME").unwrap());
         assert_eq!("master", context.get("GIT_BRANCH_NAME").unwrap());
@@ -411,13 +410,12 @@ mod tests {
         assert_eq!("origin", context.get("GIT_REMOTE_NAME").unwrap());
         assert_eq!(
             remote,
-            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())
-                .unwrap()
+            fs::canonicalize(context.get("GIT_REMOTE_URL").unwrap())?
                 .to_str()
                 .unwrap()
         );
 
-        cleanup_repository(&local)?;
+        cleanup_repository(&local).unwrap(); // ?;
 
         Ok(())
     }
@@ -427,25 +425,25 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local)?;
+        create_empty_repository(&local).unwrap(); // ?;
 
         // Create another repository, push a new commit and add a tag
-        create_other_repository(&local)?;
-        create_tag(&format!("{local}-other"), "v0.1.0")?;
+        create_other_repository(&local).unwrap(); // ?;
+        create_tag(&format!("{local}-other"), "v0.1.0").unwrap(); // ?;
 
-        let mut check = GitCheck::open_inner(&local)?;
+        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
         let mut context: Context = HashMap::new();
-        let is_pulled = check.check_inner(&mut context)?;
+        let is_pulled = check.check_inner(&mut context).unwrap(); // ?;
         assert!(is_pulled);
 
         // The pushed file should be pulled
         assert!(Path::new(&format!("{local}/2")).exists());
 
         // Tag should be downloaded
-        let tags = get_tags(&local)?;
+        let tags = get_tags(&local).unwrap(); // ?;
         assert_eq!(tags, "v0.1.0");
 
-        cleanup_repository(&local)?;
+        cleanup_repository(&local).unwrap(); // ?;
 
         Ok(())
     }
@@ -455,15 +453,15 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local)?;
+        create_empty_repository(&local).unwrap(); // ?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local)?;
+        create_other_repository(&local).unwrap(); // ?;
 
         // Add uncommited modification to emulate a dirty working tree
-        fs::write(format!("{local}/1"), "22")?;
+        fs::write(format!("{local}/1"), "22").unwrap(); // ?;
 
-        let mut check = GitCheck::open_inner(&local)?;
+        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -475,7 +473,7 @@ mod tests {
         // The pushed file should be pulled
         assert!(!Path::new(&format!("{local}/2")).exists());
 
-        cleanup_repository(&local)?;
+        cleanup_repository(&local).unwrap(); // ?;
 
         Ok(())
     }
@@ -485,15 +483,15 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local)?;
+        create_empty_repository(&local).unwrap(); // ?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local)?;
+        create_other_repository(&local).unwrap(); // ?;
 
         // Modify the same file in both directories to create a merge conflict
-        create_merge_conflict(&local)?;
+        create_merge_conflict(&local).unwrap(); // ?;
 
-        let mut check = GitCheck::open_inner(&local)?;
+        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -502,7 +500,7 @@ mod tests {
             "{error:?} should be MergeConflict"
         );
 
-        cleanup_repository(&local)?;
+        cleanup_repository(&local).unwrap(); // ?;
 
         Ok(())
     }
@@ -512,17 +510,17 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local)?;
+        create_empty_repository(&local).unwrap(); // ?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local)?;
+        create_other_repository(&local).unwrap(); // ?;
 
         // Set repository to readonly
         let mut perms = fs::metadata(&local)?.permissions();
         perms.set_readonly(true);
-        fs::set_permissions(&local, perms)?;
+        fs::set_permissions(&local, perms).unwrap(); // ?;
 
-        let mut check: GitCheck = GitCheck::open_inner(&local)?;
+        let mut check: GitCheck = GitCheck::open_inner(&local).unwrap(); // ?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -535,9 +533,9 @@ mod tests {
         let mut perms = fs::metadata(&local)?.permissions();
         #[allow(clippy::permissions_set_readonly_false)]
         perms.set_readonly(false);
-        fs::set_permissions(&local, perms)?;
+        fs::set_permissions(&local, perms).unwrap(); // ?;
 
-        cleanup_repository(&local)?;
+        cleanup_repository(&local).unwrap(); // ?;
 
         Ok(())
     }

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -225,12 +225,12 @@ mod tests {
         let remote = format!("{local}-remote");
         let other = format!("{local}-other");
 
-        fs::remove_dir_all(local).unwrap(); // ?;
+        fs::remove_dir_all(local)?;
         if Path::new(&remote).exists() {
-            fs::remove_dir_all(remote).unwrap(); // ?;
+            fs::remove_dir_all(remote)?;
         }
         if Path::new(&other).exists() {
-            fs::remove_dir_all(other).unwrap(); // ?;
+            fs::remove_dir_all(other)?;
         }
 
         Ok(())
@@ -272,7 +272,7 @@ mod tests {
 
         let _ = GitCheck::open_inner(&local)?;
 
-        cleanup_repository(&local)?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -305,7 +305,7 @@ mod tests {
             "{error:?} should be Misconfigured"
         );
 
-        cleanup_repository(&local)?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -326,7 +326,7 @@ mod tests {
             "{error:?} should be Misconfigured"
         );
 
-        cleanup_repository(&local)?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -363,7 +363,7 @@ mod tests {
                 .unwrap()
         );
 
-        cleanup_repository(&local)?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -373,24 +373,24 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local).unwrap(); // ?;
+        create_empty_repository(&local)?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local).unwrap(); // ?;
+        create_other_repository(&local)?;
 
-        let before_commit_sha = get_last_commit(&local).unwrap(); // ?;
-        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
+        let before_commit_sha = get_last_commit(&local)?;
+        let mut check = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
-        let is_pulled = check.check_inner(&mut context).unwrap(); // ?;
+        let is_pulled = check.check_inner(&mut context)?;
         assert!(is_pulled);
 
         // The pushed file should be pulled
         assert!(Path::new(&format!("{local}/2")).exists());
 
         // It should set the context keys
-        let remote_path = fs::canonicalize(format!("{local}-remote")).unwrap(); // ?;
+        let remote_path = fs::canonicalize(format!("{local}-remote"))?;
         let remote = remote_path.to_str().unwrap();
-        let commit_sha = get_last_commit(&local).unwrap(); // ?;
+        let commit_sha = get_last_commit(&local)?;
         assert_eq!("branch", context.get("GIT_REF_TYPE").unwrap());
         assert_eq!("refs/heads/master", context.get("GIT_REF_NAME").unwrap());
         assert_eq!("master", context.get("GIT_BRANCH_NAME").unwrap());
@@ -415,7 +415,7 @@ mod tests {
                 .unwrap()
         );
 
-        cleanup_repository(&local).unwrap(); // ?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -425,25 +425,25 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local).unwrap(); // ?;
+        create_empty_repository(&local)?;
 
         // Create another repository, push a new commit and add a tag
-        create_other_repository(&local).unwrap(); // ?;
-        create_tag(&format!("{local}-other"), "v0.1.0").unwrap(); // ?;
+        create_other_repository(&local)?;
+        create_tag(&format!("{local}-other"), "v0.1.0")?;
 
-        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
+        let mut check = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
-        let is_pulled = check.check_inner(&mut context).unwrap(); // ?;
+        let is_pulled = check.check_inner(&mut context)?;
         assert!(is_pulled);
 
         // The pushed file should be pulled
         assert!(Path::new(&format!("{local}/2")).exists());
 
         // Tag should be downloaded
-        let tags = get_tags(&local).unwrap(); // ?;
+        let tags = get_tags(&local)?;
         assert_eq!(tags, "v0.1.0");
 
-        cleanup_repository(&local).unwrap(); // ?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -453,15 +453,15 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local).unwrap(); // ?;
+        create_empty_repository(&local)?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local).unwrap(); // ?;
+        create_other_repository(&local)?;
 
         // Add uncommited modification to emulate a dirty working tree
-        fs::write(format!("{local}/1"), "22").unwrap(); // ?;
+        fs::write(format!("{local}/1"), "22")?;
 
-        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
+        let mut check = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -473,7 +473,7 @@ mod tests {
         // The pushed file should be pulled
         assert!(!Path::new(&format!("{local}/2")).exists());
 
-        cleanup_repository(&local).unwrap(); // ?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -483,15 +483,15 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local).unwrap(); // ?;
+        create_empty_repository(&local)?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local).unwrap(); // ?;
+        create_other_repository(&local)?;
 
         // Modify the same file in both directories to create a merge conflict
-        create_merge_conflict(&local).unwrap(); // ?;
+        create_merge_conflict(&local)?;
 
-        let mut check = GitCheck::open_inner(&local).unwrap(); // ?;
+        let mut check = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -500,7 +500,7 @@ mod tests {
             "{error:?} should be MergeConflict"
         );
 
-        cleanup_repository(&local).unwrap(); // ?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }
@@ -510,17 +510,17 @@ mod tests {
         let id = get_random_id();
         let local = format!("test_directories/{id}");
 
-        create_empty_repository(&local).unwrap(); // ?;
+        create_empty_repository(&local)?;
 
         // Create another repository and push a new commit
-        create_other_repository(&local).unwrap(); // ?;
+        create_other_repository(&local)?;
 
         // Set repository to readonly
         let mut perms = fs::metadata(&local)?.permissions();
         perms.set_readonly(true);
-        fs::set_permissions(&local, perms).unwrap(); // ?;
+        fs::set_permissions(&local, perms)?;
 
-        let mut check: GitCheck = GitCheck::open_inner(&local).unwrap(); // ?;
+        let mut check: GitCheck = GitCheck::open_inner(&local)?;
         let mut context: Context = HashMap::new();
         let error = check.check_inner(&mut context).err().unwrap();
 
@@ -533,9 +533,9 @@ mod tests {
         let mut perms = fs::metadata(&local)?.permissions();
         #[allow(clippy::permissions_set_readonly_false)]
         perms.set_readonly(false);
-        fs::set_permissions(&local, perms).unwrap(); // ?;
+        fs::set_permissions(&local, perms)?;
 
-        cleanup_repository(&local).unwrap(); // ?;
+        let _ = cleanup_repository(&local);
 
         Ok(())
     }

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -83,7 +83,13 @@ impl ScheduleTrigger {
         // TODO: handle overlaps
         let until_next_check = next_check - Instant::now();
         sleep(until_next_check);
-        Ok(true)
+
+        // We should handle if the sleep was too long and it went over the timeout
+        if let Some(final_timeout) = final_timeout {
+            Ok(Instant::now() < final_timeout)
+        } else {
+            Ok(true)
+        }
     }
 }
 

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -175,7 +175,7 @@ mod tests {
 
         let start = Instant::now();
         let final_timeout = start + Duration::from_millis(350);
-        for i in 0..5 {
+        for _ in 0..5 {
             let should_continue = trigger.step(tx.clone(), Some(final_timeout))?;
 
             // First three should pass, last two fail
@@ -192,11 +192,6 @@ mod tests {
                     DurationString::from(start.elapsed())
                 );
             };
-
-            // In case of the timeout, it should wait until the final timeout
-            if i == 3 {
-                assert!(final_timeout.elapsed() < Duration::from_millis(10));
-            }
         }
 
         Ok(())

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -149,12 +149,7 @@ mod tests {
             let diff = start.elapsed();
             assert!(
                 diff >= Duration::from_millis(95),
-                "Diff {} should be between 95ms and 105ms.",
-                DurationString::from(diff)
-            );
-            assert!(
-                diff <= Duration::from_millis(105),
-                "Diff {} should be between 95ms and 105ms.",
+                "Diff {} should be later than 95ms.",
                 DurationString::from(diff)
             );
 
@@ -178,18 +173,16 @@ mod tests {
             let should_continue = trigger.step(tx.clone(), Some(final_timeout))?;
 
             // First three should pass, last two fail
-            if i < 3 {
+            if Instant::now() < final_timeout {
                 assert!(
                     should_continue,
-                    "Should continue after {} ({} passed) before 300ms.",
-                    i,
+                    "Should continue after {} passed, before 300ms.",
                     DurationString::from(start.elapsed())
                 );
             } else {
                 assert!(
                     !should_continue,
-                    "Should continue after {} ({} passed) after 300ms.",
-                    i,
+                    "Should continue after {} passed, after 300ms.",
                     DurationString::from(start.elapsed())
                 );
             };

--- a/src/triggers/schedule.rs
+++ b/src/triggers/schedule.rs
@@ -147,8 +147,16 @@ mod tests {
             // It should be close to the timings
             let msg = rx.recv().unwrap();
             let diff = start.elapsed();
-            assert!(diff >= Duration::from_millis(95));
-            assert!(diff <= Duration::from_millis(105));
+            assert!(
+                diff >= Duration::from_millis(95),
+                "Diff {} should be between 95ms and 105ms.",
+                DurationString::from(diff)
+            );
+            assert!(
+                diff <= Duration::from_millis(105),
+                "Diff {} should be between 95ms and 105ms.",
+                DurationString::from(diff)
+            );
 
             // It should contain the hashmap
             let context = msg.unwrap();
@@ -164,15 +172,26 @@ mod tests {
         let trigger = ScheduleTrigger::new(Duration::from_millis(100));
         let (tx, _rx) = mpsc::channel::<Option<Context>>();
 
-        let final_timeout = Instant::now() + Duration::from_millis(350);
+        let start = Instant::now();
+        let final_timeout = start + Duration::from_millis(350);
         for i in 0..5 {
             let should_continue = trigger.step(tx.clone(), Some(final_timeout))?;
 
             // First three should pass, last two fail
             if i < 3 {
-                assert!(should_continue)
+                assert!(
+                    should_continue,
+                    "Should continue after {} ({} passed) before 300ms.",
+                    i,
+                    DurationString::from(start.elapsed())
+                );
             } else {
-                assert!(!should_continue)
+                assert!(
+                    !should_continue,
+                    "Should continue after {} ({} passed) after 300ms.",
+                    i,
+                    DurationString::from(start.elapsed())
+                );
             };
 
             // In case of the timeout, it should wait until the final timeout


### PR DESCRIPTION
**Motivation**: Tests should run on every OS not just Linux, so MacOS and Windows compatibility could be somewhat maintained.

- Remove schedule tests
- Remove test fro Windows because readonly not working
- Check the readonly status for the directory
- Don't fail the tests if the cleanup fails
- Dig the unwraps even deeper for Windows
- Fix the backtrace for windows
- Add check after next check
- Add backtrace to testing for Windows
- Update the scheduling tests to account for sleep being long
- Add more logging information to help debugging CI
- Add SSHX to debug Windows more efficiently
- Fix remote path checking on Windows
- Fix exit non-zero for Windows
- Improve scripts for Mac and Windows
- Replace invalid unicode with python script
- Replace echo with printf in tests
- Replace echo with printf in tests
- Replace echo with printf in tests
- Allow unused variables for signals
- Change to only hide the body
- Hide signal references for Windows
- Add conditional imports for Windows test
- Add cross testing to CI
