### PR TITLE
Add tag trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **New feature**: Trigger on git tags
+  - Use the `--on tag` to only pull to the latest tag on the branch
+  - Use `--on tag:v*` to match the tags with the given glob
+  - Git repository will stay on the branch, but will do a partial pull to the tag and run actions
 - Updated dependencies, with libgit2 updated to 1.9.0
 
 ## [0.4.0] - 2024-10-23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It is often enough to run scripts, but many times you also want to maintain a lo
 For example starting a python web server:
 
 ```sh
-$ gw /path/to/repo -v -p "python -m http.server"
+$ gw /path/to/repo -v --process "python -m http.server"
 # ...
 2024-10-06T21:58:21.306Z [DEBUG] Setting up ProcessAction "python -m http.server" on change.
 2024-10-06T21:58:21.306Z [DEBUG] Starting process: "python" in directory /path/to/repo.
@@ -111,7 +111,7 @@ This will run a python process in the background and stop and start it again if 
 Pulling on every commit might not be the fit for every product, especially ones that needs to maintains compatibility or strictly versioned. For these, you can instead trigger on tags. Use the `--on tag` flag to only pull changes if there is a tag on the current branch.
 
 ```sh
-$ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
+$ gw /path/to/repo -v --on tag -S 'echo $GIT_TAG_NAME'
 # ...
 2024-10-18T16:28:53.907Z [INFO ] There are updates, running actions.
 2024-10-18T16:28:53.907Z [INFO ] Running script "echo" in /path/to/repo.
@@ -122,7 +122,7 @@ $ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
 This will always fetch the current branch, check for the latest tag on it and pull only the commits up to that tag. To match some kind of commit, you can use the `--on tag:v*` which will only pull if the tag is matching the passed glob (in this case starting with `v`).
 
 ```sh
-gw /path/to/repo -v --on 'tag:v*' --script 'echo "new version: $GIT_TAG_NAME"'
+gw /path/to/repo -v --on 'tag:v*' -S 'echo "new version: $GIT_TAG_NAME"'
 ```
 
 ## Next steps

--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ $ gw /path/to/repo -v -p "python -m http.server"
 
 This will run a python process in the background and stop and start it again if a git pull happened. Just wrap your deployment script with `gw` and see it gets updated every time you push to git.
 
+## Run actions on tags
+
+Pulling on every commit might not be the fit for every product, especially ones that needs to maintains compatibility or strictly versioned. For these, you can instead trigger on tags. Use the `--on tag` flag to only pull changes if there is a tag on the current branch.
+
+```sh
+$ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
+# ...
+2024-10-18T16:28:53.907Z [INFO ] There are updates, running actions.
+2024-10-18T16:28:53.907Z [INFO ] Running script "echo" in /path/to/repo.
+2024-10-18T16:28:53.913Z [DEBUG] [echo] v0.1.0
+2024-10-18T16:28:53.913Z [INFO ] Script "echo" finished successfully.
+```
+
+This will always fetch the current branch, check for the latest tag on it and pull only the commits up to that tag. To match some kind of commit, you can use the `--on tag:v*` which will only pull if the tag is matching the passed glob (in this case starting with `v`).
+
+```sh
+gw /path/to/repo -v --on 'tag:v*' --script 'echo "new version: $GIT_TAG_NAME"'
+```
+
 ## Next steps
 
 If you like `gw`, there are multiple ways to use it for real-life use-cases.

--- a/docs/content/reference/commandline.md
+++ b/docs/content/reference/commandline.md
@@ -5,3 +5,83 @@ weight = 3
 
 # Command-line arguments
 
+This details the arguments that the `gw` binary takes.
+
+## Positional arguments
+
+Every `gw` execution should specify a directory to a git repository. This will be the repository which the `gw` checks to see if there are any changes and run actions.
+
+## Flag arguments
+
+`gw` follows GNU argument conventions, so every short arguments start with `-` and long arguments start with `--`.
+
+### Basic flags
+
+To get information about `gw` or change the output settings (more verbose with `-v` or quieter with `-q`), you can use these flags:
+
+| Argument name     | Example     | Notes                                                                  |
+| ----------------- | ----------- | ---------------------------------------------------------------------- |
+| `-v`, `--verbose` | `-v`, `-vv` | Increase verbosity, can be set multiple times (-v debug, -vv tracing). |
+| `-q`, `--quiet`   | `-q`        | Only print error messages.                                             |
+| `-V`, `--version` | `--version` | Print the current version.                                             |
+| `-h`, `--help`    | `--help`    | Print this help.                                                       |
+
+### Trigger flags
+
+Use these flags, to set the different modes to check for changes:
+
+-   Scheduled triggers (`-d`, default every 1 minute): check with a specified interval using [duration-string](https://github.com/Ronniskansing/duration-string) settings. Pass `0s` for disabling scheduled triggers.
+-   Trigger once (`--once`): check if there are changes and then exit immediately.
+-   Http trigger (`--http`): run an HTTP server on an interface and port (e. g. `0.0.0.0:8000`), which trigger on any incoming request. For more information, see [Webhook](/usage/webhook).
+
+| Argument name   | Example                                          | Notes                                                                  |
+| --------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
+| `-d`, `--every` | `-d 5m`, `-d 1h`, `-d 0s`                        | Refreshes the repo with this interval. (default: 1m)                   |
+| `--once`        | `--once`                                         | Try to pull only once. Useful for cronjobs.                            |
+| `--http`        | `--http localhost:1234`, `--http 127.0.0.1:4321` | Runs an HTTP server on the URL, which allows to trigger by calling it. |
+
+### Check flags
+
+These flags change the way `gw` checks the git repository for changes:
+
+-   On every push (`--on push`, default): pull the commits on the current branch and run actions if there are any new commits.
+-   On every tag (`--on tag` or `--on tag:v*`): fetch the commits on the current branch and only pull to the first tag. You can pass a glob, in which case the first tag matching the glob. If there are no matching tags, no pull happens.
+
+You can also configure the authentication for the git repository:
+
+-   SSH authentication (`-i`, `--ssh-key`): specify the path to the SSH key that will.
+-   HTTP authentication (`--git-username`, `--git-token`): specify a username-token pair.
+
+For more information see [Authentication](/reference/authentication).
+
+| Argument name      | Example                                                | Notes                                                                                           |
+| ------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `--on`             | `--on push`, `--on tag`, `--on tag:v*`                 | The trigger on which to run (can be `push`, `tag` or `tag:pattern`). (default: push)            |
+| `-i`, `--ssh-key`  | `-i ~/.ssh/test.id_rsa`                                | Set the path for an ssh-key to be used when pulling.                                            |
+| `--git-username`   | `--git-username daniel7grant`                          | Set the username for git to be used when pulling with HTTPS.                                    |
+| `--git-token`      | `--git-token 'ghp_jB3c5...'`                           | Set the token for git to be used when pulling with HTTPS.                                       |
+| `--git-known-host` | `--git-known-host 'example.com ssh-rsa AAAAB3NzaC...'` | Add this line to the known_hosts file to be created (e.g. "example.com ssh-ed25519 AAAAC3..."). |
+
+### Action flags
+
+These flags configure the actions that should be run when the changes occur. These come in two flavours lowercase letters indicate that it is run directly, while uppercase letters will run in a subshell (e.g. `/bin/sh` on Linux). This is useful if you want to expand variables, pipe commands etc. It is recommended to always use single-quotes for the argument values to avoid accidental shell issues (e.g. expanding variables at start time).
+
+-   Run scripts (`-s`, `-S`): execute a script on every change, that will be waited until it ends.
+-   Start process (`-p`, `-P`): start a process, when starting `gw`, that will be restarted on every change.
+
+You can also configure the process running:
+
+-   Retries (`--process-retries`): in case of a failed process, how many time should it be restarted, before marking it failed.
+-   Stop settings (`--stop-signal`, `--stop-timeout`): how to stop the process in case of a restart, by default sending `SIGINT` and after 10s a `SIGKILL` (supported only on `*NIX`).
+
+For more information see [Actions on pull](/usage/actions).
+
+| Argument name       | Example             | Notes                                                                                                                       |
+| ------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `-s`, `--script`    | `-s 'cat FILENAME'` | A script to run on changes, you can define multiple times.                                                                  |
+| `-S`                |                     | Run a script in a shell.                                                                                                    |
+| `-p`, `--process`   |                     | A background process that will be restarted on change.                                                                      |
+| `-P`                |                     | Run a background process in a shell.                                                                                        |
+| `--process-retries` |                     | The number of times to retry the background process in case it fails. By default 0 for no retries.                          |
+| `--stop-signal`     |                     | The stop signal to give the background process. Useful for graceful shutdowns. By default SIGINT. (Only supported on \*NIX) |
+| `--stop-timeout`    |                     | The timeout to wait before killing for the background process to shutdown gracefully. By default 10s.                       |

--- a/docs/content/reference/environment-variables.md
+++ b/docs/content/reference/environment-variables.md
@@ -26,18 +26,19 @@ These are the variables that are exposed from the trigger, which can be schedule
 
 These are the variables that are exposed from the check, which currently is always git.
 
-| Variable name                    | Example                              | Notes                                        |
-| -------------------------------- | ------------------------------------ | -------------------------------------------- |
-| `GW_CHECK_NAME`                  | `GIT`                                | The identifier of the check.                 |
-| `GW_GIT_BEFORE_COMMIT_SHA`       | `acfd4f88da199...`                   | The SHA of the commit before the pull.       |
-| `GW_GIT_BEFORE_COMMIT_SHORT_SHA` | `acfd4f8`                            | The 7-character short hash of the commit.    |
-| `GW_GIT_BRANCH_NAME`             | `main`                               | The name of the branch, that the repo is on. |
-| `GW_GIT_COMMIT_SHA`              | `acfd4f88da199...`                   | The SHA of the commit after the pull.        |
-| `GW_GIT_COMMIT_SHORT_SHA`        | `acfd4f8`                            | The 7-character short hash of the commit.    |
-| `GW_GIT_REF_NAME`                | `refs/heads/main`, `refs/tags/v1.0`  | The full name of the current git ref.        |
-| `GW_GIT_REF_TYPE`                | `branch`, `tag`                      | The type of the ref we are currently on.     |
-| `GW_GIT_REMOTE_NAME`             | `origin`                             | The name of the remote used.                 |
-| `GW_GIT_REMOTE_URL`              | `git@github.com:daniel7grant/gw.git` | The URL to the git remote.                   |
+| Variable name                    | Example                              | Notes                                         |
+| -------------------------------- | ------------------------------------ | --------------------------------------------- |
+| `GW_CHECK_NAME`                  | `GIT`                                | The identifier of the check.                  |
+| `GW_GIT_BEFORE_COMMIT_SHA`       | `acfd4f88da199...`                   | The SHA of the commit before the pull.        |
+| `GW_GIT_BEFORE_COMMIT_SHORT_SHA` | `acfd4f8`                            | The 7-character short hash of the commit.     |
+| `GW_GIT_BRANCH_NAME`             | `main`                               | The name of the branch, that the repo is on.  |
+| `GW_GIT_COMMIT_SHA`              | `acfd4f88da199...`                   | The SHA of the commit after the pull.         |
+| `GW_GIT_COMMIT_SHORT_SHA`        | `acfd4f8`                            | The 7-character short hash of the commit.     |
+| `GW_GIT_REF_NAME`                | `refs/heads/main`, `refs/tags/v1.0`  | The full name of the current git ref.         |
+| `GW_GIT_REF_TYPE`                | `branch`, `tag`                      | The type of the ref we are currently on.      |
+| `GW_GIT_REMOTE_NAME`             | `origin`                             | The name of the remote used.                  |
+| `GW_GIT_REMOTE_URL`              | `git@github.com:daniel7grant/gw.git` | The URL to the git remote.                    |
+| `GW_GIT_TAG_NAME`                | `v1.0`                               | The tag of the pulled commit if there is one. |
 
 ## Action variables
 

--- a/docs/content/reference/environment-variables.md
+++ b/docs/content/reference/environment-variables.md
@@ -9,7 +9,9 @@ The different steps can add variables to the context, which are exposed to the s
 All of these are prefixed with `GW_` to avoid collisions. The second part usually identifies the specific trigger,
 check or action.
 
-A good way to debug environment variables is to print the variables with `-s "printenv"`.
+If you want to use the environment variables in [command-line arguments](/reference/commandline), make sure to use the subshell variants (`-S`, `-P`),
+because only these can expand variables. It is recommended to use single-quotes to avoid expanding at start time. A good way
+to debug environment variables is to print them with `-S 'printenv'`.
 
 ## Trigger variables
 

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -88,6 +88,25 @@ This will run a python process in the background and stop and start it again if 
 
 For more information, see [Processes](/usage/actions#processes).
 
+## Run actions on tags
+
+Pulling on every commit might not be the fit for every product, especially ones that needs to maintains compatibility or strictly versioned. For these, you can instead trigger on tags. Use the `--on tag` flag to only pull changes if there is a tag on the current branch.
+
+```sh
+$ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
+# ...
+2024-10-18T16:28:53.907Z [INFO ] There are updates, running actions.
+2024-10-18T16:28:53.907Z [INFO ] Running script "echo" in /path/to/repo.
+2024-10-18T16:28:53.913Z [DEBUG] [echo] v0.1.0
+2024-10-18T16:28:53.913Z [INFO ] Script "echo" finished successfully.
+```
+
+This will always fetch the current branch, check for the latest tag on it and pull only the commits up to that tag. To match some kind of commit, you can use the `--on tag:v*` which will only pull if the tag is matching the passed glob (in this case starting with `v`).
+
+```sh
+gw /path/to/repo -v --on 'tag:v*' --script 'echo "new version: $GIT_TAG_NAME"'
+```
+
 ## Next steps
 
 If you like `gw`, there are multiple ways to use it for real-life use-cases.

--- a/docs/content/usage/start.md
+++ b/docs/content/usage/start.md
@@ -93,7 +93,7 @@ For more information, see [Processes](/usage/actions#processes).
 Pulling on every commit might not be the fit for every product, especially ones that needs to maintains compatibility or strictly versioned. For these, you can instead trigger on tags. Use the `--on tag` flag to only pull changes if there is a tag on the current branch.
 
 ```sh
-$ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
+$ gw /path/to/repo -v --on tag -S 'echo $GIT_TAG_NAME'
 # ...
 2024-10-18T16:28:53.907Z [INFO ] There are updates, running actions.
 2024-10-18T16:28:53.907Z [INFO ] Running script "echo" in /path/to/repo.
@@ -104,7 +104,7 @@ $ gw /path/to/repo -v --on tag --script 'echo $GIT_TAG_NAME'
 This will always fetch the current branch, check for the latest tag on it and pull only the commits up to that tag. To match some kind of commit, you can use the `--on tag:v*` which will only pull if the tag is matching the passed glob (in this case starting with `v`).
 
 ```sh
-gw /path/to/repo -v --on 'tag:v*' --script 'echo "new version: $GIT_TAG_NAME"'
+gw /path/to/repo -v --on 'tag:v*' -S 'echo "new version: $GIT_TAG_NAME"'
 ```
 
 ## Next steps

--- a/src/args.rs
+++ b/src/args.rs
@@ -63,12 +63,12 @@ pub struct Args {
     pub once: bool,
 
     /// The trigger on which to run (can be `push`, `tag` or `tag:pattern`).
-    /// 
+    ///
     /// The options are:
     /// - `push`: update on every commit,
     /// - `tag`: update on every tag on this branch,
     /// - `tag:pattern`: update on tags matching the glob.
-    #[options(default = "push")]
+    #[options(no_short, long = "on", default = "push")]
     pub trigger: TriggerArgument,
 
     /// Refreshes the repo with this interval.

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,7 @@ impl FromStr for TriggerArgument {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "push" => Ok(TriggerArgument::Push),
+            "tag" => Ok(TriggerArgument::Tag("*".to_string())),
             s if s.starts_with("tag:") => Ok(TriggerArgument::Tag(
                 s.trim_start_matches("tag:").to_string(),
             )),
@@ -61,7 +62,12 @@ pub struct Args {
     #[options(long = "once", no_short)]
     pub once: bool,
 
-    /// The trigger on which to run (can be `push` or `tag:prefix`).
+    /// The trigger on which to run (can be `push`, `tag` or `tag:pattern`).
+    /// 
+    /// The options are:
+    /// - `push`: update on every commit,
+    /// - `tag`: update on every tag on this branch,
+    /// - `tag:pattern`: update on tags matching the glob.
     #[options(default = "push")]
     pub trigger: TriggerArgument,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,7 +19,7 @@ impl FromStr for TriggerArgument {
             s if s.starts_with("tag:") => Ok(TriggerArgument::Tag(
                 s.trim_start_matches("tag:").to_string(),
             )),
-            s => Err(format!("cannot parse {s}, valid values: push, tag:prefix")),
+            s => Err(format!("cannot parse {s}, valid values: push, tag, tag:prefix")),
         }
     }
 }

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -162,13 +162,13 @@ impl GitCheck {
                     Ok(true)
                 }
                 GitTriggerArgument::Tag(pattern) => {
-                    let tags = repo.find_tags(fetch_commit.id(), pattern)?;
-                    if let Some((tag_name, commit)) = tags.last() {
-                        repo.pull(*commit)?;
+                    let mut tags = repo.find_tags(fetch_commit.id(), pattern)?;
+                    if let Some((tag_name, commit)) = tags.pop() {
+                        repo.pull(commit)?;
                         context.insert("GIT_REF_TYPE", "tag".to_string());
                         context.insert("GIT_REF_NAME", format!("refs/tags/{tag_name}"));
                         context.insert("GIT_COMMIT_SHA", commit.to_string());
-                        context.insert("GIT_COMMIT_SHORT_SHA", shorthash(commit));
+                        context.insert("GIT_COMMIT_SHORT_SHA", shorthash(&commit));
                         context.insert("GIT_COMMIT_TAG_NAME", tag_name.to_string());
                         Ok(true)
                     } else {

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -12,6 +12,7 @@ mod repository;
 use config::setup_gitconfig;
 pub use credentials::CredentialAuth;
 use known_hosts::setup_known_hosts;
+use repository::shorthash;
 
 const CHECK_NAME: &str = "GIT";
 
@@ -155,12 +156,19 @@ impl GitCheck {
             match trigger {
                 GitTriggerArgument::Push => {
                     let result = repo.pull(fetch_commit.id())?;
+                    context.insert("GIT_COMMIT_SHA", fetch_commit.id().to_string());
+                    context.insert(
+                        "GIT_COMMIT_SHORT_SHA",
+                        shorthash(&fetch_commit.id().to_string()),
+                    );
                     Ok(result)
                 }
                 GitTriggerArgument::Tag(pattern) => {
                     let tags = repo.find_tags(fetch_commit.id(), pattern)?;
                     if let Some(tag) = tags.last() {
                         let result = repo.pull(*tag)?;
+                        context.insert("GIT_COMMIT_SHA", tag.to_string());
+                        context.insert("GIT_COMMIT_SHORT_SHA", shorthash(&tag.to_string()));
                         Ok(result)
                     } else {
                         Ok(false)

--- a/src/checks/git/repository.rs
+++ b/src/checks/git/repository.rs
@@ -212,7 +212,7 @@ impl GitRepository {
         }
 
         if tags.is_empty() {
-            trace!("There is no new commit with tag matching \"{pattern}\".");
+            debug!("There is no new commit with tag matching \"{pattern}\".");
         }
 
         // Put it into chronological order

--- a/src/checks/git/repository.rs
+++ b/src/checks/git/repository.rs
@@ -148,6 +148,7 @@ impl GitRepository {
             .reference_to_annotated_commit(&fetch_head)
             .map_err(|err| GitError::FetchFailed(err.message().trim().to_string()))?;
 
+        // TODO: update message to make it clear that it is not pulled only fetched
         trace!(
             "Fetched successfully to {}.",
             fetch_head

--- a/src/checks/git/repository.rs
+++ b/src/checks/git/repository.rs
@@ -151,7 +151,7 @@ impl GitRepository {
             "Fetched successfully to {}.",
             fetch_head
                 .peel_to_commit()
-                .map(|c| c.id().to_string()[0..7].to_string())
+                .map(|c| shorthash(&c.id().to_string()))
                 .unwrap_or("unknown reference".to_string())
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn main_inner() -> Result<(), MainError> {
     }
 
     // Setup check.
+    // TODO: update log message
     debug!("Setting up directory {directory} for GitCheck.");
     let mut git_check = GitCheck::open(&directory, args.git_known_host, args.trigger.into())?;
     if let Some(ssh_key) = args.ssh_key {

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main_inner() -> Result<(), MainError> {
 
     // Setup check.
     debug!("Setting up directory {directory} for GitCheck.");
-    let mut git_check = GitCheck::open(&directory, args.git_known_host)?;
+    let mut git_check = GitCheck::open(&directory, args.git_known_host, args.trigger.into())?;
     if let Some(ssh_key) = args.ssh_key {
         git_check.set_auth(CredentialAuth::Ssh(ssh_key));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,9 @@ fn main_inner() -> Result<(), MainError> {
     }
 
     // Setup check.
-    // TODO: update log message
-    debug!("Setting up directory {directory} for GitCheck.");
-    let mut git_check = GitCheck::open(&directory, args.git_known_host, args.trigger.into())?;
+    let git_trigger = args.trigger.into();
+    debug!("Setting up GitCheck for \"{directory}\" on every {git_trigger}.");
+    let mut git_check = GitCheck::open(&directory, args.git_known_host, git_trigger)?;
     if let Some(ssh_key) = args.ssh_key {
         git_check.set_auth(CredentialAuth::Ssh(ssh_key));
     }


### PR DESCRIPTION
**Motivation**: Currently, you cannot trigger based on the tags on a branch. Add a feature to the git trigger which walks through the pulled commits and checks out the latest tag, while staying on the branch.

- Refactor context keys to contain tag information
- Add logging and improve error handling
- Fix tests and add more TODOs
- Add tag pull implementation
- Add argument to handle tags
