### PR TITLE
Emit a warning only, when known hosts or gitconfig creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- If known hosts or gitconfig creation fails, only a warning is emitted now (#49)
 - Updated test dependencies
 - Updated ureq to avoid ring vulnerability
 - Updated duct to 1.0.0

--- a/src/checks/git.rs
+++ b/src/checks/git.rs
@@ -127,8 +127,11 @@ impl GitCheck {
         additional_host: Option<String>,
         trigger: GitTriggerArgument,
     ) -> Result<Self, CheckError> {
-        setup_known_hosts(additional_host)?;
-        setup_gitconfig(directory)?;
+        let known_hosts_failed = setup_known_hosts(additional_host).is_err();
+        let gitconfig_failed = setup_gitconfig(directory).is_err();
+        if known_hosts_failed || gitconfig_failed {
+            warn!("Setting up known hosts or git configuration failed. Check if home directory exists and the permissions are correct.");
+        };
 
         GitCheck::open_inner(directory, trigger)
     }

--- a/src/checks/git/config.rs
+++ b/src/checks/git/config.rs
@@ -1,7 +1,7 @@
 use super::GitError;
 use dirs::home_dir;
-use std::{fs::File, io::Write, path::PathBuf};
 use log::warn;
+use std::{fs::File, io::Write, path::PathBuf};
 
 /// Setup the gitconfig file.
 ///
@@ -14,15 +14,15 @@ pub fn setup_gitconfig(directory: &str) -> Result<(), GitError> {
     let config = home.join(".gitconfig");
 
     if !config.exists() {
+        let mut config_file = File::create(&config).map_err(|_| GitError::ConfigLoadingFailed)?;
+        writeln!(config_file, "[safe]\n  directory = {directory}")
+            .map_err(|_| GitError::ConfigLoadingFailed)?;
+
         warn!(
-            "There is no {}, creating with safe.directory = {}.",
+            "There is no {}, created with safe.directory = {}.",
             config.to_string_lossy(),
             directory
         );
-
-        let mut config_file = File::create(config).map_err(|_| GitError::ConfigLoadingFailed)?;
-        writeln!(config_file, "[safe]\n  directory = {directory}")
-            .map_err(|_| GitError::ConfigLoadingFailed)?;
     }
 
     Ok(())

--- a/src/checks/git/known_hosts.rs
+++ b/src/checks/git/known_hosts.rs
@@ -53,26 +53,26 @@ pub fn setup_known_hosts(additional_host: Option<String>) -> Result<(), GitError
                 .open(&known_hosts)
                 .map_err(|_| GitError::SshConfigFailed)?;
 
+            writeln!(known_hosts_file, "{host}").map_err(|_| GitError::SshConfigFailed)?;
             debug!(
-                "Host key not found in {}, adding from arguments.",
+                "Host key not found in {}, added from arguments.",
                 known_hosts.to_string_lossy()
             );
-            writeln!(known_hosts_file, "{host}").map_err(|_| GitError::SshConfigFailed)?;
         }
     } else if !known_hosts.exists() {
         let mut known_hosts_file =
             File::create(&known_hosts).map_err(|_| GitError::SshConfigFailed)?;
 
-        warn!(
-            "There is no {}, creating with default fingerprints.",
-            known_hosts.to_string_lossy()
-        );
         writeln!(known_hosts_file, "{GITHUB_FINGERPRINTS}")
             .map_err(|_| GitError::SshConfigFailed)?;
         writeln!(known_hosts_file, "{GITLAB_FINGERPRINTS}")
             .map_err(|_| GitError::SshConfigFailed)?;
         writeln!(known_hosts_file, "{BITBUCKET_FINGERPRINTS}")
             .map_err(|_| GitError::SshConfigFailed)?;
+        warn!(
+            "There is no {}, created with default fingerprints.",
+            known_hosts.to_string_lossy()
+        );
     }
 
     Ok(())


### PR DESCRIPTION
**Motivation**: `gw` sets up gitconfig and known hosts with some default values to make it easier to run in a container. However if these files cannot be created, for example the home directory is not existent or the permissions are denied, the process crashes. Instead of crashing, emit a warning and continue running. Closes #49 

- Emit a warning only, when known hosts or gitconfig creation fails